### PR TITLE
Fix for L/h -> m3/s unit conversion

### DIFF
--- a/pgns/127489.js
+++ b/pgns/127489.js
@@ -31,7 +31,7 @@ module.exports = [
     },
     value: function(n2k) {
       var lph = Number(n2k.fields['Fuel Rate'])
-      return lph * 0.00000028;      
+      return lph / 3600000;      
     }
   }, {
     node: 'propulsion.starboard.fuel.rate',
@@ -40,7 +40,7 @@ module.exports = [
     },
     value: function(n2k) {
       var lph = Number(n2k.fields['Fuel Rate'])
-      return lph * 0.00000028;      
+      return lph / 3600000;      
     }
   }, {
     node: 'propulsion.port.oilPressure',

--- a/test/127489_engine_params.js
+++ b/test/127489_engine_params.js
@@ -14,7 +14,7 @@ describe('127489 engine parameters Port', function () {
     tree.should.have.deep.property('propulsion.port.alternatorVoltage');
     tree.should.have.deep.property('propulsion.port.alternatorVoltage.value', 12.60);
     tree.should.have.deep.property('propulsion.port.fuel.rate');
-    tree.should.have.deep.property('propulsion.port.fuel.rate.value', 1.1200000000000001e-07);
+    tree.should.have.deep.property('propulsion.port.fuel.rate.value', 1.1111111111111112e-7);
     tree.should.have.deep.property('propulsion.port.runTime');
     tree.should.have.deep.property('propulsion.port.runTime.value', 309960);
     tree.should.have.deep.property('propulsion.port.oilPressure');
@@ -34,7 +34,7 @@ describe('127489 engine parameters Starboard', function () {
     tree.should.have.deep.property('propulsion.starboard.alternatorVoltage');
     tree.should.have.deep.property('propulsion.starboard.alternatorVoltage.value', 12.60);
     tree.should.have.deep.property('propulsion.starboard.fuel.rate');
-    tree.should.have.deep.property('propulsion.starboard.fuel.rate.value', 2.8000000000000003e-8);
+    tree.should.have.deep.property('propulsion.starboard.fuel.rate.value', 2.777777777777778e-8);
     tree.should.have.deep.property('propulsion.starboard.runTime');
     tree.should.have.deep.property('propulsion.starboard.runTime.value', 309960);
     tree.should.have.deep.property('propulsion.starboard.oilPressure');


### PR DESCRIPTION
Instead of using rounded multiplier 0.0000028 for L/h -> m3/s conversion, divide by 3600000, which is algebraically more accurate, and may help avoid error accumulation elsewhere.