### PR TITLE
fix: provide a null delta when timeRemaining changes to unknown

### DIFF
--- a/pgns/127506.js
+++ b/pgns/127506.js
@@ -16,7 +16,21 @@ module.exports = [
       return 'electrical.batteries.' + n2k.fields['DC Instance'] + '.capacity.stateOfHealth'
     }
   },{
-    source: 'Time Remaining',
+    value: function(n2k, state) {
+      var val = n2k.fields['Time Remaining']
+      console.log("state: " + state)
+      var res
+      if ( typeof val !== 'undefined' ) {
+        res = val * 60; //convert to seconds
+      } else if ( state && typeof state.lastTimeRemaining !== 'undefined' ) {
+        res = null;
+      }
+      if ( state ) {
+        state.lastTimeRemaining = val;
+      }
+      console.log("returning: " + val)
+      return res;
+    },
     node: function(n2k) {
       return 'electrical.batteries.' + n2k.fields['DC Instance'] + '.capacity.timeRemaining'
     }

--- a/test/127506_dc_detailed_status.js
+++ b/test/127506_dc_detailed_status.js
@@ -2,15 +2,23 @@ var chai = require("chai");
 chai.Should();
 chai.use(require('chai-things'));
 
+var state = {}
 
 describe('127506 dc detailed status', function () {
   it('complete sentence converts', function () {
     var tree = require("../n2kMapper.js").toNested(
-      JSON.parse('{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"DC Instance":1,"State of Charge":60,"State of Health":99,"Time Remaining": 600, "Ripple Voltage": 10.9, "SID":0}}'));
+      JSON.parse('{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"DC Instance":1,"State of Charge":60,"State of Health":99,"Time Remaining": 600, "Ripple Voltage": 10.9, "SID":0}}'), state);
     tree.should.have.nested.property('electrical.batteries.1.capacity.stateOfCharge.value', .60);
     tree.should.have.nested.property('electrical.batteries.1.capacity.stateOfHealth.value', 99);
-    tree.should.have.nested.property('electrical.batteries.1.capacity.timeRemaining.value', 600);
+    tree.should.have.nested.property('electrical.batteries.1.capacity.timeRemaining.value', 36000);
     //tree.should.have.nested.property('electrical.batteries.1.voltage.ripple.value', 10.9);
     tree.should.be.validSignalKVesselIgnoringIdentity;
+  });
+
+  it('null timeRemaining converts', function () {
+    var delta = require("../n2kMapper.js").toDelta(
+      JSON.parse('{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"DC Instance":1,"SID":0}}'), state);
+    delta.updates[0].values[0].should.have.property('path', 'electrical.batteries.1.capacity.timeRemaining');
+    delta.updates[0].values[0].should.have.property('value', null);
   });
 });


### PR DESCRIPTION

This includes the state changes from #72 

I am tempted to change n2kMapper to do this null delta for all fields in all PGNs. I think that makes sense, then each pgn would not have to have code for checking state like this.

That would mean keeping state for every single value in n2k. 