### PR TITLE
feature: cleanup: remove toNested and options, make schema a devDependency

### DIFF
--- a/bin/demo.js
+++ b/bin/demo.js
@@ -17,5 +17,3 @@ var msg = {
 
 console.log(".toDelta()\n----------");
 console.log(JSON.stringify(n2kMapper.toDelta(msg), null, 2));
-console.log("\n.toNested()\n-----------");
-console.log(JSON.stringify(n2kMapper.toNested(msg), null, 2));

--- a/bin/n2k-signalk
+++ b/bin/n2k-signalk
@@ -3,20 +3,6 @@
 var n2kMapper = require('../n2kMapper.js');
 var JSONStream = require('JSONStream');
 
-var opts = require("nomnom")
-  .option('debug', {
-    abbr: 'd',
-    flag: true,
-    help: 'Print debugging info'
-  })
-  .option('delta', {
-    flag: true,
-    help: 'Produce delta (non-nested) output'
-  }).parse();
-
-process.stdin.resume();
 process.stdin.setEncoding('utf8');
 
-var transformer = opts.delta ? n2kMapper.toDeltaTransformer(opts) : n2kMapper.toNestedTransformer(opts);
-
-process.stdin.pipe(JSONStream.parse()).pipe(transformer).pipe(JSONStream.stringify(false)).pipe(process.stdout);
+process.stdin.pipe(JSONStream.parse()).pipe(n2kMapper.toDeltaTransformer()).pipe(JSONStream.stringify(false)).pipe(process.stdout);

--- a/n2kMapper.js
+++ b/n2kMapper.js
@@ -1,5 +1,4 @@
 var n2kMappings = require('./n2kMappings.js').mappings
-var signalkSchema = require('@signalk/signalk-schema')
 var through = require('through')
 var debug = require('debug')('signalk:n2k-signalk')
 
@@ -145,36 +144,8 @@ function addAsNested (pathValue, source, timestamp, result) {
 }
 
 exports.toDelta = toDelta
-exports.toNested = function (n2k, state) {
-  var delta = toDelta(n2k, state)
-  if (!delta.context) {
-    delta.context = 'vessels.' + signalkSchema.fakeMmsiId
-  }
-
-  var contextParts = delta.context.split('.')
-
-  return signalkSchema.deltaToFull(delta)[contextParts[0]][contextParts[1]]
-}
-
 exports.toDeltaTransformer = function (options) {
-  var stream = through(function (data) {
-    if (options.debug) {
-      console.log(data)
-    }
-    stream.queue(exports.toDelta(data))
+  return through(function (data) {
+    this.queue(exports.toDelta(data))
   })
-  return stream
-}
-
-exports.toNestedTransformer = function (options) {
-  var stream = through(function (data) {
-    if (options.debug) {
-      console.log(data)
-    }
-    var nested = exports.toNested(data)
-    if (Object.getOwnPropertyNames(nested).length > 0) {
-      stream.queue(nested)
-    }
-  })
-  return stream
 }

--- a/package.json
+++ b/package.json
@@ -23,11 +23,10 @@
   "dependencies": {
     "JSONStream": "~1.3.0",
     "debug": "^3.0.0",
-    "nomnom": "~1.8.1",
-    "@signalk/signalk-schema": "0.0.1-10",
     "through": ">=2.2.7 <3"
   },
   "devDependencies": {
+    "@signalk/signalk-schema": "0.0.1-10",
     "chai": "~4.1.0",
     "chai-things": "0.2",
     "github-changes": "^1.0.4",

--- a/test/126992_time.js
+++ b/test/126992_time.js
@@ -4,7 +4,7 @@ chai.use(require('chai-things'))
 
 describe('126992 system time', function () {
   it('complete sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2013-10-08-16:04:06.044Z","prio":"3","src":"1","dst":"255","pgn":"126992","description":"System Time","fields":{"SID":"222","Date":"2013.10.08", "Time": "16:04:00"}}'
       )

--- a/test/127245_rudder.js
+++ b/test/127245_rudder.js
@@ -4,7 +4,7 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('127245_rudder ', function () {
   it('complete sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2013-10-08T15:47:28.263Z","prio":"2","src":"204","dst":"255","pgn":"127245","description":"Rudder","fields":{"Instance":"0","Position":"-0.7"}}'
       )
@@ -18,7 +18,7 @@ describe('127245_rudder ', function () {
   })
 
   it('direction order is not handled', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2013-10-08-15:47:28.263Z","prio":"2","src":"204","dst":"255","pgn":"127245","description":"Rudder","fields":{"Instance":"252","Direction Order":"0"}}'
       )

--- a/test/127250_heading.js
+++ b/test/127250_heading.js
@@ -5,7 +5,7 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('127250 Heading', function () {
   it('Magnetic sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2013-10-08-15:47:28.263Z","prio":"2","src":"204","dst":"255","pgn":"127250","description":"Vessel Heading","fields":{"Heading":"129.7","Reference":"Magnetic"}}'
       )
@@ -18,7 +18,7 @@ describe('127250 Heading', function () {
   })
 
   it('Variation sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2013-10-08-15:47:28.264Z","prio":"2","src":"1","dst":"255","pgn":"127250","description":"Vessel Heading","fields":{"SID":"68","Variation":"8.0","Reference":"True"}}'
       )
@@ -31,7 +31,7 @@ describe('127250 Heading', function () {
   })
 
   it('True heading sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-04-14T09:34:11.275Z","prio":2,"src":2,"dst":255,"pgn":127250,"description":"Vessel Heading","fields":{"Heading":14.8,"Deviation":0.0,"Variation":0.0,"Reference":"True"}}'
       )

--- a/test/127257_attitude.js
+++ b/test/127257_attitude.js
@@ -5,7 +5,7 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('127257_attitude', function () {
   it('complete sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2013-10-08-15:47:28.263Z","prio":"2","src":"204","dst":"255","pgn":"127257","description":"Attitude","fields":{"Yaw":"37.190","Pitch":"0.464","Roll":"-2.496"}}'
       )

--- a/test/127258_variation.js
+++ b/test/127258_variation.js
@@ -4,7 +4,7 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('127258_variation ', function () {
   it('complete sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2015-01-15-16:25:11.333Z","prio":7,"src":4,"dst":255,"pgn":127258,"description":"Magnetic Variation","fields":{"SID":247,"Variation":16.1}}'
       )

--- a/test/127488_engine_speed.js
+++ b/test/127488_engine_speed.js
@@ -5,7 +5,7 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('127488 engine speed Port', function () {
   it('complete engine speed sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2015-01-15-16:16:56.749Z","prio":"2","src":"17","dst":"255","pgn":"127488","description":"Engine Parameters, Rapid Update","fields":{"Engine Instance":"Single Engine or Dual Engine Port","Engine Speed":"3190"}}'
       )
@@ -21,7 +21,7 @@ describe('127488 engine speed Port', function () {
 
 describe('127488 engine speed Starboard', function () {
   it('complete engine speed sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2015-01-15-16:16:56.749Z","prio":"2","src":"17","dst":"255","pgn":"127488","description":"Engine Parameters, Rapid Update","fields":{"Engine Instance":"Dual Engine Starboard","Engine Speed":"3190"}}'
       )

--- a/test/127489_engine_params.js
+++ b/test/127489_engine_params.js
@@ -5,7 +5,7 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('127489 engine parameters Port', function () {
   it('complete engine params sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489",	"description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Single Engine or Dual Engine Port","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80}}'
       )
@@ -46,7 +46,7 @@ describe('127489 engine parameters Port', function () {
 
 describe('127489 engine parameters Starboard', function () {
   it('complete engine params sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489","description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.1","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":["Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque": 57,"Oil pressure":80}}'
       )
@@ -98,7 +98,7 @@ describe('127489 engine parameters Starboard', function () {
       'alarm')
     tree.should.be.validSignalKVesselIgnoringIdentity
 
-    tree = require('../n2kMapper.js').toNested(
+    tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489","description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.1","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure"],"Discrete Status 2": [],"Percent Engine Load": 20,"Percent Engine Torque": 57,"Oil pressure":80}}'
       )

--- a/test/127505_fluid_level.js
+++ b/test/127505_fluid_level.js
@@ -5,7 +5,7 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('127505 fuel', function () {
   it('just level, no capacity', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2015-01-15-16:15:30.984Z","prio":"6","src":"17","dst":"255","pgn":"127505","description":"Fluid Level","fields":{"Instance":"0","Type":"Fuel","Level":"131.068"}}'
       )
@@ -14,7 +14,7 @@ describe('127505 fuel', function () {
     tree.should.be.validSignalKVesselIgnoringIdentity
   })
   it('level and capacity', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2015-01-15-16:15:33.341Z","prio":"6","src":"112","dst":"255","pgn":"127505","description":"Fluid Level","fields":{"Instance":"1","Type":"Fuel","Level":"64.284","Capacity":"41.6"}}'
       )
@@ -27,7 +27,7 @@ describe('127505 fuel', function () {
 
 describe('127505 water', function () {
   it('level and capacity', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2015-01-15-16:15:33.366Z","prio":"6","src":"114","dst":"255","pgn":"127505","description":"Fluid Level","fields":{"Instance":"0","Type":"Water","Level":"88.596","Capacity":"71.9"}}'
       )
@@ -43,7 +43,7 @@ describe('127505 water', function () {
 
 describe('127505 grayWater', function () {
   it('level and capacity', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2015-01-15-16:15:33.369Z","prio":"6","src":"113","dst":"255","pgn":"127505","description":"Fluid Level","fields":{"Instance":"0","Type":"Gray water","Level":"90.240","Capacity":"37.9"}}'
       )

--- a/test/127506_dc_detailed_status.js
+++ b/test/127506_dc_detailed_status.js
@@ -4,7 +4,7 @@ chai.use(require('chai-things'))
 
 describe('127506 dc detailed status', function () {
   it('complete sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"DC Instance":1,"State of Charge":60,"State of Health":99,"Time Remaining": 600, "Ripple Voltage": 10.9, "SID":0}}'
       )
@@ -26,8 +26,8 @@ describe('127506 dc detailed status', function () {
   })
   it('null timeRemaining converts', function () {
     var pgn = '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"DC Instance":1,"SID":0}}'
-    var delta = require('../n2kMapper.js').toDelta(JSON.parse(pgn))
-    tree = require('../n2kMapper.js').toNested(JSON.parse(pgn))
+    var delta = require('./testMapper').toDelta(JSON.parse(pgn))
+    tree = require('./testMapper').toNested(JSON.parse(pgn))
 
     delta.updates[0].values[0].should.have.property(
       'path',

--- a/test/127508_battery_voltage.js
+++ b/test/127508_battery_voltage.js
@@ -4,7 +4,7 @@ chai.use(require('chai-things'))
 
 describe('127508 battery voltage', function () {
   it('complete sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127508,"description":"Battery Status","fields":{"Battery Instance":1,"Voltage":13.11,"Current":5.6,"Temperature": 299, "SID":0}}'
       )

--- a/test/128259_speed.js
+++ b/test/128259_speed.js
@@ -5,7 +5,7 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('128259 speed', function () {
   it('complete sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2014-08-15-18:00:30.175Z","prio":"2","src":"115","dst":"255","pgn":"128259","description":"Speed","fields":{"SID":"0","Speed Water Referenced":"3.47","Speed Water Referenced Type":"-0"}}'
       )

--- a/test/128267_water_depth.js
+++ b/test/128267_water_depth.js
@@ -5,7 +5,7 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('128267_water_depth', function () {
   it('complete positive offset sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2013-10-08-15:47:28.280Z","prio":"3","src":"1","dst":"255","pgn":"128267","description":"Water Depth","fields":{"SID":"91","Depth":"8.20", "Offset":0.304}}'
       )
@@ -26,7 +26,7 @@ describe('128267_water_depth', function () {
   })
 
   it('complete negative offset sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2013-10-08-15:47:28.280Z","prio":"3","src":"1","dst":"255","pgn":"128267","description":"Water Depth","fields":{"SID":"91","Depth":"8.20", "Offset":-0.304}}'
       )

--- a/test/128275_log.js
+++ b/test/128275_log.js
@@ -5,7 +5,7 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('128275 log', function () {
   it('complete sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2013-10-08-16:04:06.060Z","prio":"6","src":"1","dst":"255","pgn":"128275","description":"Distance Log","fields":{"Log":"2229808","Trip Log":"4074"}}'
       )

--- a/test/129025_position.js
+++ b/test/129025_position.js
@@ -8,14 +8,14 @@ var msg = JSON.parse(
 
 describe('129025 Position, rapid update ', function () {
   it('complete sentence converts to tree', function () {
-    var tree = require('../n2kMapper.js').toNested(msg)
+    var tree = require('./testMapper').toNested(msg)
     tree.navigation.position.longitude.should.equal(24.7921348)
     tree.navigation.position.latitude.should.equal(60.144554)
     tree.should.be.validSignalKVesselIgnoringIdentity
   })
 
   it('complete sentence produces valid delta', function () {
-    var delta = require('../n2kMapper.js').toDelta(msg)
+    var delta = require('./testMapper').toDelta(msg)
     delta.should.be.validSignalKDelta
   })
 })

--- a/test/129026_cog_sog_rapid_update.js
+++ b/test/129026_cog_sog_rapid_update.js
@@ -5,7 +5,7 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('129026 COG & SOG, Rapid Update', function () {
   it('complete sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2014-08-15-18:00:10.005Z","prio":"2","src":"160","dst":"255","pgn":"129026","description":"COG & SOG, Rapid Update","fields":{"COG Reference":"True","COG":"206.1","SOG":"3.65"}}'
       )
@@ -21,7 +21,7 @@ describe('129026 COG & SOG, Rapid Update', function () {
   })
 
   it('just COG converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2015-01-15-16:25:12.021Z","prio":2,"src":245,"dst":255,"pgn":129026,"description":"COG & SOG, Rapid Update","fields":{"SID":138,"COG Reference":"True","SOG":0.00}}'
       )

--- a/test/129029_position_data.js
+++ b/test/129029_position_data.js
@@ -13,7 +13,7 @@ const invalidDataMsg = JSON.parse(
 
 describe('129029 Position Data ', function () {
   it('complete sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(msg)
+    var tree = require('./testMapper').toNested(msg)
     tree.navigation.position.longitude.should.equal(-76.3972731)
     tree.navigation.position.latitude.should.equal(39.0536632)
     tree.navigation.gnss.antennaAltitude.value.should.equal(1.0)
@@ -29,7 +29,7 @@ describe('129029 Position Data ', function () {
     tree.should.be.validSignalKVesselIgnoringIdentity
   })
   it('no position in input produces no position output', function() {
-    var delta = require('../n2kMapper.js').toDelta(invalidDataMsg)
+    var delta = require('./testMapper').toDelta(invalidDataMsg)
     delta.updates[0].values.should.not.contain.a.thing.with.property('path', 'navigation.position')
   })
 })

--- a/test/129038_ais_class_a.js
+++ b/test/129038_ais_class_a.js
@@ -3,7 +3,7 @@ chai.Should()
 chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
-var mapper = require('../n2kMapper.js')
+var mapper = require('./testMapper')
 
 describe('129038 Class A Update', function () {
   it('complete sentence converts', function () {

--- a/test/129039_ais_class_b.js
+++ b/test/129039_ais_class_b.js
@@ -3,7 +3,7 @@ chai.Should()
 chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
-var mapper = require('../n2kMapper.js')
+var mapper = require('./testMapper')
 
 describe('129039 Class B Update', function () {
   it('complete sentence converts', function () {

--- a/test/129040_class_b_extended.js
+++ b/test/129040_class_b_extended.js
@@ -3,7 +3,7 @@ chai.Should()
 chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
-var mapper = require('../n2kMapper.js')
+var mapper = require('./testMapper')
 
 describe('129040 AIS Class B Extended Position Repeat', function () {
   it('complete sentence converts', function () {

--- a/test/129041_aton_report.js
+++ b/test/129041_aton_report.js
@@ -3,7 +3,7 @@ chai.Should()
 chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
-var mapper = require('../n2kMapper.js')
+var mapper = require('./testMapper')
 
 describe('129041 AIS Aids to Navigation (AtoN) Report', function () {
   it('complete sentence converts', function () {

--- a/test/129283_xte.js
+++ b/test/129283_xte.js
@@ -3,7 +3,7 @@ chai.Should()
 chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
-const mapper = require('../n2kMapper.js')
+const mapper = require('./testMapper')
 
 var state = {}
 

--- a/test/129284_navigation_data.js
+++ b/test/129284_navigation_data.js
@@ -3,7 +3,7 @@ chai.Should()
 chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
-var mapper = require('../n2kMapper.js')
+var mapper = require('./testMapper')
 
 describe('129284 Navigation Data', function () {
   it('complete sentence converts', function () {

--- a/test/129291_set_drift_rapid_update.js
+++ b/test/129291_set_drift_rapid_update.js
@@ -4,7 +4,7 @@ chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('129291 set & drift rapid update complete sentence', function () {
-  var tree = require('../n2kMapper.js').toNested(
+  var tree = require('./testMapper').toNested(
     JSON.parse(
       '{"timestamp":"2014-08-15-18:00:06.573Z","prio":"3","src":"160","dst":"255","pgn":"129291","description":"Set & Drift, Rapid Update","fields":{"Set Reference":"True","Set":"212.6","Drift":"0.24"}}'
     )

--- a/test/129794_ais_class_a_static_data.js
+++ b/test/129794_ais_class_a_static_data.js
@@ -36,7 +36,7 @@ chai.Should()
 chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
-var mapper = require('../n2kMapper.js')
+var mapper = require('./testMapper')
 
 describe('129794 AIS Class A Static and Voyage Related Data', function () {
   it('complete sentence converts', function () {

--- a/test/129809_ais_class_b_static_data.js
+++ b/test/129809_ais_class_b_static_data.js
@@ -3,7 +3,7 @@ chai.Should()
 chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
-var mapper = require('../n2kMapper.js')
+var mapper = require('./testMapper')
 
 describe('129809 Class B static data', function () {
   it('complete sentence converts', function () {

--- a/test/130306_wind_data.js
+++ b/test/130306_wind_data.js
@@ -5,7 +5,7 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('130306 Wind Data', function () {
   it('Apparent sentence converts positive', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2013-10-08-15:47:28.263Z","prio":"2","src":"1","dst":"255","pgn":"130306","description":"Wind Data","fields":{"SID":"67","Wind Speed":"6.22","Wind Angle":"0.872665","Reference":"Apparent"}}'
       )
@@ -22,7 +22,7 @@ describe('130306 Wind Data', function () {
   })
 
   it('Apparent sentence converts positive gt 180', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2013-10-08-15:47:28.263Z","prio":"2","src":"1","dst":"255","pgn":"130306","description":"Wind Data","fields":{"SID":"67","Wind Speed":"6.22","Wind Angle":"3.31613","Reference":"Apparent"}}'
       )
@@ -39,7 +39,7 @@ describe('130306 Wind Data', function () {
   })
 
   it('Apparent sentence converts negative', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2013-10-08-15:47:28.263Z","prio":"2","src":"1","dst":"255","pgn":"130306","description":"Wind Data","fields":{"SID":"67","Wind Speed":"6.22","Wind Angle":"-0.872665","Reference":"Apparent"}}'
       )
@@ -56,7 +56,7 @@ describe('130306 Wind Data', function () {
   })
 
   it('True Boat sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2013-10-08-15:47:28.264Z","prio":"2","src":"1","dst":"255","pgn":"130306","description":"Wind Data","fields":{"SID":"68","Wind Speed":"4.89","Wind Angle":"86.0","Reference":"True (boat referenced)"}}'
       )
@@ -70,7 +70,7 @@ describe('130306 Wind Data', function () {
   })
 
   it('True Ground sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2013-10-08-15:47:28.264Z","prio":"2","src":"3","dst":"255","pgn":"130306","description":"Wind Data","fields":{"SID":"94","Wind Speed":"4.82","Wind Angle":"218.6","Reference":"True (ground referenced to North)"}}'
       )

--- a/test/13031_temperature.js
+++ b/test/13031_temperature.js
@@ -9,7 +9,7 @@ var msgs = require('./130310-2.json')
 
 describe('Temperature: ', function () {
   it('examples work', function () {
-    var n2kMapper = require('../n2kMapper.js')
+    var n2kMapper = require('./testMapper')
     var full = new (require('@signalk/signalk-schema')).FullSignalK(
       'urn:mrn:imo:mmsi:230099999'
     )

--- a/test/130577_direction_data.js
+++ b/test/130577_direction_data.js
@@ -4,7 +4,7 @@ chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('130577 direction_data sentence without drift', function () {
-  var tree = require('../n2kMapper.js').toNested(
+  var tree = require('./testMapper').toNested(
     JSON.parse(
       '{"timestamp":"2014-08-15-10:01:35.236Z","prio":"3","src":"160","dst":"255","pgn":"130577","description":"Direction Data","fields":{"Data Mode":"Autonomous","COG Reference":"True","SID":"21","COG":"70.1","SOG":"0.01"}}'
     )
@@ -27,7 +27,7 @@ describe('130577 direction_data sentence without drift', function () {
 })
 
 describe('130577 direction_data sentence with drift', function () {
-  var tree = require('../n2kMapper.js').toNested(
+  var tree = require('./testMapper').toNested(
     JSON.parse(
       '{"timestamp":"2014-08-15-18:00:00.755Z","prio":"3","src":"160","dst":"255","pgn":"130577","description":"Direction Data","fields":{"Data Mode":"Autonomous","COG Reference":"True","SID":"84","COG":"206.9","SOG":"3.51","Set":"58.9","Drift":"0.28"}}'
     )

--- a/test/130820_fusion.js
+++ b/test/130820_fusion.js
@@ -5,7 +5,7 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('130820 Fusion Stereo', function () {
   it('complet device name sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-11-26T20:40:00.895Z","prio":7,"src":10,"dst":255,"pgn":130820,"description":"Fusion: Unit Name","fields":{"Manufacturer Code":"Fusion","Industry Code":"Marine Industry","Message ID":"Unit Name","A":128,"Name":"Fusion"}}'
       )
@@ -14,7 +14,7 @@ describe('130820 Fusion Stereo', function () {
   })
 
   it('complet current source sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-11-26T20:40:00.901Z","prio":7,"src":10,"dst":255,"pgn":130820,"description":"Fusion: Source Name","fields":{"Manufacturer Code":"Fusion","Industry Code":"Marine Industry","Message ID":"Source","A":128,"Source ID":4,"Current Source ID":4,"D":3,"E":5,"Source":"SiriusXM"}}'
       )
@@ -31,7 +31,7 @@ describe('130820 Fusion Stereo', function () {
   })
 
   it('complet SiriusXM channel sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-11-26T20:40:00.906Z","prio":7,"src":10,"dst":255,"pgn":130820,"description":"Fusion: SiriusXM Channel","fields":{"Manufacturer Code":"Fusion","Industry Code":"Marine Industry","Message ID":"SiriusXM Channel","A":6554752,"Channel":"xL Howard 100"}}'
       )
@@ -44,7 +44,7 @@ describe('130820 Fusion Stereo', function () {
   })
 
   it('complet SiriusXM Genre sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-11-26T20:40:00.911Z","prio":7,"src":10,"dst":255,"pgn":130820,"description":"Fusion: SiriusXM Genre","fields":{"Manufacturer Code":"Fusion","Industry Code":"Marine Industry","Message ID":"SiriusXM Genre","A":6554752,"Genre":"Howard Stern"}}'
       )
@@ -57,7 +57,7 @@ describe('130820 Fusion Stereo', function () {
   })
 
   it('complet SiriusXM title sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-11-26T20:40:00.915Z","prio":7,"src":10,"dst":255,"pgn":130820,"description":"Fusion: SiriusXM Title","fields":{"Manufacturer Code":"Fusion","Industry Code":"Marine Industry","Message ID":"SiriusXM Title","A":6554752,"Title":"A title"}}'
       )
@@ -70,7 +70,7 @@ describe('130820 Fusion Stereo', function () {
   })
 
   it('complet SiriusXM Artist sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-11-26T20:40:00.918Z","prio":7,"src":10,"dst":255,"pgn":130820,"description":"Fusion: SiriusXM Artist","fields":{"Manufacturer Code":"Fusion","Industry Code":"Marine Industry","Message ID":"SiriusXM Artist","A":6554752,"Artist":"Howard Stern"}}'
       )
@@ -83,7 +83,7 @@ describe('130820 Fusion Stereo', function () {
   })
 
   it('complet mute sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-11-26T20:40:00.973Z","prio":7,"src":10,"dst":255,"pgn":130820,"description":"Fusion: Mute","fields":{"Manufacturer Code":"Fusion","Industry Code":"Marine Industry","Message ID":"Mute","A":128,"Mute":"Not Muted"}}'
       )
@@ -96,7 +96,7 @@ describe('130820 Fusion Stereo', function () {
   })
 
   it('complete equalizer sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-11-26T20:40:00.986Z","prio":7,"src":10,"dst":255,"pgn":130820,"description":"Fusion: Tone","fields":{"Manufacturer Code":"Fusion","Industry Code":"Marine Industry","Message ID":"Tone","A":128,"B":3,"Bass":1,"Mid":2,"Treble":3}}'
       )
@@ -117,7 +117,7 @@ describe('130820 Fusion Stereo', function () {
   })
 
   it('complet volume sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-11-26T20:40:00.991Z","prio":7,"src":10,"dst":255,"pgn":130820,"description":"Fusion: Volume","fields":{"Manufacturer Code":"Fusion","Industry Code":"Marine Industry","Message ID":"Volume","A":128,"Zone 1":10,"Zone 2":11,"Zone 3":12,"Zone 4":13}}'
       )
@@ -142,7 +142,7 @@ describe('130820 Fusion Stereo', function () {
   })
 
   it('complet zone name sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-11-26T20:40:00.996Z","prio":7,"src":10,"dst":255,"pgn":130820,"description":"Fusion: Zone Name","fields":{"Manufacturer Code":"Fusion","Industry Code":"Marine Industry","Message ID":"Zone Name","A":128,"Number":0,"Name":"Cockpit"}}'
       )
@@ -155,7 +155,7 @@ describe('130820 Fusion Stereo', function () {
   })
 
   it('complet track name sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-11-12T20:26:52.150Z","prio":7,"src":10,"dst":255,"pgn":130820,"description":"Fusion: Track","fields":{"Manufacturer Code":"Fusion","Industry Code":"Marine Industry","Message ID":"Track Title","A":128,"B":3592,"Track":"Flow"}}'
       )

--- a/test/130842_simnet_class_b_extended.js
+++ b/test/130842_simnet_class_b_extended.js
@@ -3,7 +3,7 @@ chai.Should()
 chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
-var mapper = require('../n2kMapper.js')
+var mapper = require('./testMapper')
 
 describe('130842 Simnet AIS Class B static data', function () {
   it('complete part A sentence converts', function () {

--- a/test/65288_seatalk_alarm.js
+++ b/test/65288_seatalk_alarm.js
@@ -5,7 +5,7 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('65288 Seatalk Alarm', function () {
   it('complete alarm sentence converts waypoint advance alarm with sound', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-10-18T15:52:48.152Z","prio":7,"src":204,"dst":255,"pgn":65288,"description":"Seatalk: Alarm","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Alarm Status":"Alarm condition met and not silenced","Alarm ID":"Pilot Way Point Advance","Alarm Group":"Autopilot","Alarm Priority":"0"}}'
       )
@@ -23,7 +23,7 @@ describe('65288 Seatalk Alarm', function () {
   })
 
   it('complete alarm sentence converts waypoint advance normal', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-10-18T15:52:49.063Z","prio":7,"src":204,"dst":255,"pgn":65288,"description":"Seatalk: Alarm","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Alarm Status":"Alarm condition not met","Alarm ID":"Pilot Way Point Advance","Alarm Group":"Autopilot","Alarm Priority":"0"}}'
       )
@@ -37,7 +37,7 @@ describe('65288 Seatalk Alarm', function () {
   })
 
   it('complete alarm sentence converts waypoint advance alarm silenced', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-10-18T15:54:16.750Z","prio":7,"src":204,"dst":255,"pgn":65288,"description":"Seatalk: Alarm","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Alarm Status":"Alarm condition met and silenced","Alarm ID":"Pilot Way Point Advance","Alarm Group":"Autopilot","Alarm Priority":"0"}}'
       )

--- a/test/65345_seatalk_pilot_wind.js
+++ b/test/65345_seatalk_pilot_wind.js
@@ -5,7 +5,7 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('65345 Seatalk Wind Datum', function () {
   it('complet wind datum sentence converts positive', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-09-06T23:01:38.825Z","prio":7,"src":204,"dst":255,"pgn":65345,"description":"Seatalk: Pilot Wind Datum","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Wind Datum":1.0265,"Rolling Average Wind Angle":5.0195}}'
       )
@@ -18,7 +18,7 @@ describe('65345 Seatalk Wind Datum', function () {
   })
 
   it('complet wind datum sentence converts negative', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-09-06T23:01:38.825Z","prio":7,"src":204,"dst":255,"pgn":65345,"description":"Seatalk: Pilot Wind Datum","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Wind Datum":5.1454,"Rolling Average Wind Angle":5.0195}}'
       )

--- a/test/65360_seatalk_pilot_locked_heading.js
+++ b/test/65360_seatalk_pilot_locked_heading.js
@@ -5,7 +5,7 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('65360 Seatalk Pilot Locked Heading', function () {
   it('complet wind datum sentence converts', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-10-18T15:52:49.041Z","prio":7,"src":204,"dst":255,"pgn":65360,"description":"Seatalk: Pilot Locked Heading","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Target Heading True":3.0422,"Target Heading Magnetic":3.0122}}'
       )
@@ -21,7 +21,7 @@ describe('65360 Seatalk Pilot Locked Heading', function () {
     tree.should.be.validSignalKVesselIgnoringIdentity
   })
   it('complet wind datum sentence converts mag', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-10-18T15:52:49.041Z","prio":7,"src":204,"dst":255,"pgn":65360,"description":"Seatalk: Pilot Locked Heading","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Target Heading Magnetic":3.0422}}'
       )
@@ -33,7 +33,7 @@ describe('65360 Seatalk Pilot Locked Heading', function () {
     tree.should.be.validSignalKVesselIgnoringIdentity
   })
   it('complet wind datum sentence converts true', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-10-18T15:52:49.041Z","prio":7,"src":204,"dst":255,"pgn":65360,"description":"Seatalk: Pilot Locked Heading","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Target Heading True":3.0422}}'
       )

--- a/test/65379_seatalk_pilot_mode.js
+++ b/test/65379_seatalk_pilot_mode.js
@@ -5,7 +5,7 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('65379 Seatalk Pilot Mode', function () {
   it('complet pilot mode sentence converts track', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-10-18T15:52:49.048Z","prio":7,"src":204,"dst":255,"pgn":65379,"description":"Seatalk: Pilot Mode","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Pilot Mode":"129","Sub Mode":"1","Pilot Mode Data":"0"}}'
       )
@@ -15,7 +15,7 @@ describe('65379 Seatalk Pilot Mode', function () {
   })
 
   it('complet pilot mode sentence converts auto', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-09-06T22:56:27.719Z","prio":7,"src":204,"dst":255,"pgn":65379,"description":"Seatalk: Pilot Mode","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Pilot Mode":"64","Sub Mode":"0","Pilot Mode Data":"0"}}'
       )
@@ -25,7 +25,7 @@ describe('65379 Seatalk Pilot Mode', function () {
   })
 
   it('complet pilot mode sentence converts wind', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-09-06T23:01:38.822Z","prio":7,"src":204,"dst":255,"pgn":65379,"description":"Seatalk: Pilot Mode","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Pilot Mode":"0","Sub Mode":"1","Pilot Mode Data":"0"}}'
       )
@@ -35,7 +35,7 @@ describe('65379 Seatalk Pilot Mode', function () {
   })
 
   it('complet pilot mode sentence converts standby', function () {
-    var tree = require('../n2kMapper.js').toNested(
+    var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-10-18T15:52:00.751Z","prio":7,"src":204,"dst":255,"pgn":65379,"description":"Seatalk: Pilot Mode","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Pilot Mode":"0","Sub Mode":"0","Pilot Mode Data":"0"}}'
       )

--- a/test/errorhandling.js
+++ b/test/errorhandling.js
@@ -1,7 +1,7 @@
 const chai = require('chai')
 chai.Should()
 const assert = require('assert')
-const mapper = require('../n2kMapper.js')
+const mapper = require('./testMapper')
 
 describe('Unknown pgn', function () {
   it('returns delta with one update that has no values', function () {

--- a/test/testMapper.js
+++ b/test/testMapper.js
@@ -1,0 +1,12 @@
+const n2kMapper = require('../n2kMapper')
+const signalkSchema = require('@signalk/signalk-schema')
+
+n2kMapper.toNested = function (n2k, state) {
+  var delta = n2kMapper.toDelta(n2k, state)
+  if (!delta.context) {
+    delta.context = 'vessels.' + signalkSchema.fakeMmsiId
+  }
+  var contextParts = delta.context.split('.')
+  return signalkSchema.deltaToFull(delta)[contextParts[0]][contextParts[1]]
+}
+module.exports = n2kMapper


### PR DESCRIPTION
Remove toNested which I assume nobody is using, while removing
command line utitilies which are probably also not in any use.
This allows making signalk-schema a dev depency.