### PR TITLE
Add missing fields to PGN 127489 parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,24 +87,14 @@
       "integrity": "sha512-tlTQk4bFcHENOnGbyDpaZ/LlttgK3BF5IGAH8jIjnomkcguw63vpbmaLyiqCaFqMWfq8a67Hed5p0Apmwr99yg==",
       "dev": true,
       "requires": {
-        "JSONStream": "0.7.4",
         "debug": "2.6.9",
         "json-schema-ref-parser": "3.3.1",
+        "JSONStream": "0.7.4",
         "lodash": "3.10.1",
         "tv4": "1.3.0",
         "tv4-formats": "2.2.2"
       },
       "dependencies": {
-        "JSONStream": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
-          "integrity": "sha1-c0KQ5BUR7qfCz+FR+/mlY6l7l4Y=",
-          "dev": true,
-          "requires": {
-            "jsonparse": "0.0.5",
-            "through": "2.3.8"
-          }
-        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -120,21 +110,22 @@
           "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=",
           "dev": true
         },
+        "JSONStream": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+          "integrity": "sha1-c0KQ5BUR7qfCz+FR+/mlY6l7l4Y=",
+          "dev": true,
+          "requires": {
+            "jsonparse": "0.0.5",
+            "through": "2.3.8"
+          }
+        },
         "lodash": {
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
-      }
-    },
-    "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
       }
     },
     "abbrev": {
@@ -1455,6 +1446,15 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
+    "JSONStream": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -2370,6 +2370,12 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -2379,12 +2385,6 @@
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
     },
     "strip-ansi": {
       "version": "4.0.0",

--- a/pgns/127489.js
+++ b/pgns/127489.js
@@ -1,32 +1,32 @@
 const util = require('util')
 
-function skEngineId(n2k) {
-  return n2k.fields['Engine Instance'] === 'Single Engine or Dual Engine Port' ? "port" : "starboard";
+function skEngineId (n2k) {
+  return n2k.fields['Engine Instance'] === 'Single Engine or Dual Engine Port' ? 'port' : 'starboard'
 }
 
-function skEngineTitle(n2k) {
-  var engine = skEngineId(n2k);
-  return engine.charAt(0).toUpperCase() + engine.slice(1);
+function skEngineTitle (n2k) {
+  var engine = skEngineId(n2k)
+  return engine.charAt(0).toUpperCase() + engine.slice(1)
 }
 
 module.exports = [
   {
     source: 'Temperature',
-    node: function(n2k) { return 'propulsion.' + skEngineId(n2k) + '.temperature'},
+    node: function (n2k) { return 'propulsion.' + skEngineId(n2k) + '.temperature' }
   },
   {
     source: 'Alternator Potential',
-    node: function(n2k) { return 'propulsion.' + skEngineId(n2k) + '.alternatorVoltage' },
+    node: function (n2k) { return 'propulsion.' + skEngineId(n2k) + '.alternatorVoltage' }
   },
   {
-    node: function(n2k) { return 'propulsion.' + skEngineId(n2k) + '.fuel.rate' },
+    node: function (n2k) { return 'propulsion.' + skEngineId(n2k) + '.fuel.rate' },
     value: function (n2k) {
       var lph = Number(n2k.fields['Fuel Rate'])
       return lph / 3600000
     }
   },
   {
-    node: function(n2k) { return 'propulsion.' + skEngineId(n2k) + '.oilPressure' },
+    node: function (n2k) { return 'propulsion.' + skEngineId(n2k) + '.oilPressure' },
     value: function (n2k) {
       var kpa = Number(n2k.fields['Oil pressure'])
       return kpa * 1000.0
@@ -34,20 +34,32 @@ module.exports = [
   },
   {
     source: 'Total Engine hours',
-    node: function(n2k) { return 'propulsion.' + skEngineId(n2k) + '.runTime' },
+    node: function (n2k) { return 'propulsion.' + skEngineId(n2k) + '.runTime' }
   },
   {
-    node: function(n2k) { return 'propulsion.' + skEngineId(n2k) + '.engineLoad'},
+    node: function (n2k) { return 'propulsion.' + skEngineId(n2k) + '.engineLoad' },
     value: function (n2k) {
       var percent = Number(n2k.fields['Percent Engine Load'])
       return percent / 100.0
     }
   },
   {
-    node: function(n2k) { return 'propulsion.' + skEngineId(n2k) + '.engineTorque' },
+    node: function (n2k) { return 'propulsion.' + skEngineId(n2k) + '.engineTorque' },
     value: function (n2k) {
       var percent = Number(n2k.fields['Percent Engine Torque'])
       return percent / 100.0
+    }
+  },
+  {
+    node: function (n2k) { return 'propulsion.' + skEngineId(n2k) + '.fuel.pressure' },
+    value: function (n2k) {
+      var kpa = Number(n2k.fields['Fuel Pressure'])
+
+      if (isNaN(kpa) || !n2k.fields.hasOwnProperty('Fuel Pressure')) {
+        return null
+      }
+
+      return kpa * 1000.0
     }
   }
 ]
@@ -133,10 +145,10 @@ var status1Notifications = [
     message: '%s Engine Emergency Stop Mode',
     analyzerText: 'Emergency Stop'
   }
-];
+]
 
 var status2Notifications = [
-  { 
+  {
     node: 'notifications.propulsion.%s.warningLevel1',
     message: '%s Engine Warning Level 1',
     analyzerText: 'Warning Level 1'
@@ -176,37 +188,34 @@ var status2Notifications = [
     message: '%s Engine Shutting Down',
     analyzerText: 'Engine Shutting Down'
   }
-];
+]
 
-
-function generateMappingsForStatus(field, notifications)
-{
-  notifications.forEach((notif,index) => {
+function generateMappingsForStatus (field, notifications) {
+  notifications.forEach((notif, index) => {
     var mapping = {
-      node: function(n2k) {
-        return util.format(notif.node, skEngineId(n2k));
+      node: function (n2k) {
+        return util.format(notif.node, skEngineId(n2k))
       },
-      filter: function(n2k) { return typeof n2k.fields[field] !== 'undefined'; },
-      value: function(n2k, state) {
-        if ( n2k.fields[field].indexOf(notif.analyzerText) != -1  ) {
-            return {
-              state: 'alarm',
-              method: [ "visual", "sound" ],
-              message: util.format(notif.message, skEngineTitle(n2k))
-            }
+      filter: function (n2k) { return typeof n2k.fields[field] !== 'undefined' },
+      value: function (n2k, state) {
+        if (n2k.fields[field].indexOf(notif.analyzerText) != -1) {
+          return {
+            state: 'alarm',
+            method: [ 'visual', 'sound' ],
+            message: util.format(notif.message, skEngineTitle(n2k))
+          }
         } else {
           return {
             state: 'normal',
-            method: [ "visual" ],
+            method: [ 'visual' ],
             message: util.format(notif.message, skEngineTitle(n2k)) + ' is Normal'
           }
         }
       }
     }
-    module.exports.push(mapping);
-  });
+    module.exports.push(mapping)
+  })
 }
 
-generateMappingsForStatus('Discrete Status 1', status1Notifications);
-generateMappingsForStatus('Discrete Status 2', status2Notifications);
-
+generateMappingsForStatus('Discrete Status 1', status1Notifications)
+generateMappingsForStatus('Discrete Status 2', status2Notifications)

--- a/pgns/127489.js
+++ b/pgns/127489.js
@@ -37,6 +37,17 @@ module.exports = [
     node: function (n2k) { return 'propulsion.' + skEngineId(n2k) + '.runTime' }
   },
   {
+    source: 'Oil temperature',
+    node: function (n2k) { return 'propulsion.' + skEngineId(n2k) + '.oilTemperature' }
+  },
+  {
+    node: function (n2k) { return 'propulsion.' + skEngineId(n2k) + '.coolantPressure' },
+    value: function (n2k) {
+      var kpa = Number(n2k.fields['Coolant Pressure'])
+      return kpa * 1000.0
+    }
+  },
+  {
     node: function (n2k) { return 'propulsion.' + skEngineId(n2k) + '.engineLoad' },
     value: function (n2k) {
       var percent = Number(n2k.fields['Percent Engine Load'])

--- a/pgns/127489.js
+++ b/pgns/127489.js
@@ -22,14 +22,14 @@ module.exports = [
     node: function (n2k) { return 'propulsion.' + skEngineId(n2k) + '.fuel.rate' },
     value: function (n2k) {
       var lph = Number(n2k.fields['Fuel Rate'])
-      return lph / 3600000
+      return isNaN(lph) ? null : lph / 3600000
     }
   },
   {
     node: function (n2k) { return 'propulsion.' + skEngineId(n2k) + '.oilPressure' },
     value: function (n2k) {
       var kpa = Number(n2k.fields['Oil pressure'])
-      return kpa * 1000.0
+      return isNaN(kpa) ? null : kpa * 1000.0
     }
   },
   {
@@ -44,33 +44,28 @@ module.exports = [
     node: function (n2k) { return 'propulsion.' + skEngineId(n2k) + '.coolantPressure' },
     value: function (n2k) {
       var kpa = Number(n2k.fields['Coolant Pressure'])
-      return kpa * 1000.0
+      return isNaN(kpa) ? null : kpa * 1000.0
     }
   },
   {
     node: function (n2k) { return 'propulsion.' + skEngineId(n2k) + '.engineLoad' },
     value: function (n2k) {
       var percent = Number(n2k.fields['Percent Engine Load'])
-      return percent / 100.0
+      return isNaN(percent) ? null : percent / 100.0
     }
   },
   {
     node: function (n2k) { return 'propulsion.' + skEngineId(n2k) + '.engineTorque' },
     value: function (n2k) {
       var percent = Number(n2k.fields['Percent Engine Torque'])
-      return percent / 100.0
+      return isNaN(percent) ? null : percent / 100.0
     }
   },
   {
     node: function (n2k) { return 'propulsion.' + skEngineId(n2k) + '.fuel.pressure' },
     value: function (n2k) {
       var kpa = Number(n2k.fields['Fuel Pressure'])
-
-      if (isNaN(kpa) || !n2k.fields.hasOwnProperty('Fuel Pressure')) {
-        return null
-      }
-
-      return kpa * 1000.0
+      return isNaN(kpa) ? null : kpa * 1000.0
     }
   }
 ]

--- a/test/127489_engine_params.js
+++ b/test/127489_engine_params.js
@@ -7,12 +7,17 @@ describe('127489 engine parameters Port', function () {
   it('complete engine params sentence converts', function () {
     var tree = require('./testMapper').toNested(
       JSON.parse(
-        '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489", "description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Single Engine or Dual Engine Port","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80,"Fuel Pressure":504}}'
+        '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489", "description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Single Engine or Dual Engine Port","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80,"Fuel Pressure":504,"Oil temperature":36,"Coolant Pressure":489}}'
       )
     )
 
+    tree.should.have.nested.property('propulsion.port.oilTemperature')
+    tree.should.have.nested.property('propulsion.port.oilTemperature.value', 36)
+    tree.should.have.nested.property('propulsion.port.coolantPressure')
+    tree.should.have.nested.property('propulsion.port.coolantPressure.value', 489000)
     tree.should.have.nested.property('propulsion.port.fuel.pressure')
     tree.should.have.nested.property('propulsion.port.fuel.pressure.value', 504000)
+
     tree.should.have.nested.property('propulsion.port.temperature')
     tree.should.have.nested.property('propulsion.port.temperature.value', 29.85)
     tree.should.have.nested.property('propulsion.port.alternatorVoltage')
@@ -51,9 +56,17 @@ describe('127489 engine parameters Starboard', function () {
   it('complete engine params sentence converts', function () {
     var tree = require('./testMapper').toNested(
       JSON.parse(
-        '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489","description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.1","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":["Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque": 57,"Oil pressure":80}}'
+        '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489", "description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80,"Fuel Pressure":504,"Oil temperature":36,"Coolant Pressure":489}}'
       )
     )
+
+    tree.should.have.nested.property('propulsion.starboard.oilTemperature')
+    tree.should.have.nested.property('propulsion.starboard.oilTemperature.value', 36)
+    tree.should.have.nested.property('propulsion.starboard.coolantPressure')
+    tree.should.have.nested.property('propulsion.starboard.coolantPressure.value', 489000)
+    tree.should.have.nested.property('propulsion.starboard.fuel.pressure')
+    tree.should.have.nested.property('propulsion.starboard.fuel.pressure.value', 504000)
+
     tree.should.have.nested.property('propulsion.starboard.temperature')
     tree.should.have.nested.property(
       'propulsion.starboard.temperature.value',
@@ -67,7 +80,7 @@ describe('127489 engine parameters Starboard', function () {
     tree.should.have.nested.property('propulsion.starboard.fuel.rate')
     tree.should.have.nested.property(
       'propulsion.starboard.fuel.rate.value',
-      2.777777777777778e-8
+      1.1111111111111112e-7
     )
     tree.should.have.nested.property('propulsion.starboard.runTime')
     tree.should.have.nested.property(
@@ -99,25 +112,6 @@ describe('127489 engine parameters Starboard', function () {
     tree.should.have.nested.property(
       'notifications.propulsion.starboard.maintenanceNeeded.value.state',
       'alarm')
-    tree.should.be.validSignalKVesselIgnoringIdentity
-
-    tree = require('./testMapper').toNested(
-      JSON.parse(
-        '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489","description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.1","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure"],"Discrete Status 2": [],"Percent Engine Load": 20,"Percent Engine Torque": 57,"Oil pressure":80}}'
-      )
-    )
-    tree.should.have.nested.property(
-      'notifications.propulsion.starboard.lowOilPressure.value.state',
-      'alarm')
-    tree.should.have.nested.property(
-      'notifications.propulsion.starboard.lowCoolantLevel.value.state',
-      'normal')
-    tree.should.have.nested.property(
-      'notifications.propulsion.starboard.warningLevel1.value.state',
-      'normal')
-    tree.should.have.nested.property(
-      'notifications.propulsion.starboard.maintenanceNeeded.value.state',
-      'normal')
     tree.should.be.validSignalKVesselIgnoringIdentity
   })
 })

--- a/test/127489_engine_params.js
+++ b/test/127489_engine_params.js
@@ -7,9 +7,12 @@ describe('127489 engine parameters Port', function () {
   it('complete engine params sentence converts', function () {
     var tree = require('./testMapper').toNested(
       JSON.parse(
-        '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489",	"description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Single Engine or Dual Engine Port","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80}}'
+        '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489", "description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Single Engine or Dual Engine Port","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80,"Fuel Pressure":504}}'
       )
     )
+
+    tree.should.have.nested.property('propulsion.port.fuel.pressure')
+    tree.should.have.nested.property('propulsion.port.fuel.pressure.value', 504000)
     tree.should.have.nested.property('propulsion.port.temperature')
     tree.should.have.nested.property('propulsion.port.temperature.value', 29.85)
     tree.should.have.nested.property('propulsion.port.alternatorVoltage')

--- a/test/127489_engine_params.js
+++ b/test/127489_engine_params.js
@@ -4,7 +4,7 @@ chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('127489 engine parameters Port', function () {
-  it('complete engine params sentence converts', function () {
+  it('every field in the PGN from the NMEA2000 spec converts', function () {
     var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489", "description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Single Engine or Dual Engine Port","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80,"Fuel Pressure":504,"Oil temperature":36,"Coolant Pressure":489}}'
@@ -50,10 +50,49 @@ describe('127489 engine parameters Port', function () {
       'alarm')
     tree.should.be.validSignalKVesselIgnoringIdentity
   })
+
+  it('complete engine params sentence converts', function () {
+    var tree = require('./testMapper').toNested(
+      JSON.parse(
+        '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489",	"description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Single Engine or Dual Engine Port","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80}}'
+      )
+    )
+    tree.should.have.nested.property('propulsion.port.temperature')
+    tree.should.have.nested.property('propulsion.port.temperature.value', 29.85)
+    tree.should.have.nested.property('propulsion.port.alternatorVoltage')
+    tree.should.have.nested.property(
+      'propulsion.port.alternatorVoltage.value',
+      12.6
+    )
+    tree.should.have.nested.property('propulsion.port.fuel.rate')
+    tree.should.have.nested.property(
+      'propulsion.port.fuel.rate.value',
+      1.1111111111111112e-7
+    )
+    tree.should.have.nested.property('propulsion.port.runTime')
+    tree.should.have.nested.property('propulsion.port.runTime.value', 309960)
+    tree.should.have.nested.property('propulsion.port.oilPressure')
+    tree.should.have.nested.property('propulsion.port.oilPressure.value', 80000)
+    tree.should.have.nested.property('propulsion.port.engineLoad.value', 0.2)
+    tree.should.have.nested.property('propulsion.port.engineTorque.value', 0.57)
+    tree.should.have.nested.property(
+      'notifications.propulsion.port.lowOilPressure.value.state',
+      'alarm')
+    tree.should.have.nested.property(
+      'notifications.propulsion.port.lowCoolantLevel.value.state',
+      'alarm')
+    tree.should.have.nested.property(
+      'notifications.propulsion.port.warningLevel1.value.state',
+      'alarm')
+    tree.should.have.nested.property(
+      'notifications.propulsion.port.maintenanceNeeded.value.state',
+      'alarm')
+    tree.should.be.validSignalKVesselIgnoringIdentity
+  })
 })
 
 describe('127489 engine parameters Starboard', function () {
-  it('complete engine params sentence converts', function () {
+  it('every field in the PGN from the NMEA2000 spec converts', function () {
     var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489", "description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80,"Fuel Pressure":504,"Oil temperature":36,"Coolant Pressure":489}}'
@@ -68,6 +107,45 @@ describe('127489 engine parameters Starboard', function () {
     tree.should.have.nested.property('propulsion.starboard.fuel.pressure.value', 504000)
 
     tree.should.have.nested.property('propulsion.starboard.temperature')
+    tree.should.have.nested.property('propulsion.starboard.temperature.value', 29.85)
+    tree.should.have.nested.property('propulsion.starboard.alternatorVoltage')
+    tree.should.have.nested.property(
+      'propulsion.starboard.alternatorVoltage.value',
+      12.6
+    )
+    tree.should.have.nested.property('propulsion.starboard.fuel.rate')
+    tree.should.have.nested.property(
+      'propulsion.starboard.fuel.rate.value',
+      1.1111111111111112e-7
+    )
+    tree.should.have.nested.property('propulsion.starboard.runTime')
+    tree.should.have.nested.property('propulsion.starboard.runTime.value', 309960)
+    tree.should.have.nested.property('propulsion.starboard.oilPressure')
+    tree.should.have.nested.property('propulsion.starboard.oilPressure.value', 80000)
+    tree.should.have.nested.property('propulsion.starboard.engineLoad.value', 0.2)
+    tree.should.have.nested.property('propulsion.starboard.engineTorque.value', 0.57)
+    tree.should.have.nested.property(
+      'notifications.propulsion.starboard.lowOilPressure.value.state',
+      'alarm')
+    tree.should.have.nested.property(
+      'notifications.propulsion.starboard.lowCoolantLevel.value.state',
+      'alarm')
+    tree.should.have.nested.property(
+      'notifications.propulsion.starboard.warningLevel1.value.state',
+      'alarm')
+    tree.should.have.nested.property(
+      'notifications.propulsion.starboard.maintenanceNeeded.value.state',
+      'alarm')
+    tree.should.be.validSignalKVesselIgnoringIdentity
+  })
+
+  it('complete engine params sentence converts', function () {
+    var tree = require('./testMapper').toNested(
+      JSON.parse(
+        '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489","description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.1","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":["Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque": 57,"Oil pressure":80}}'
+      )
+    )
+    tree.should.have.nested.property('propulsion.starboard.temperature')
     tree.should.have.nested.property(
       'propulsion.starboard.temperature.value',
       29.85
@@ -80,7 +158,7 @@ describe('127489 engine parameters Starboard', function () {
     tree.should.have.nested.property('propulsion.starboard.fuel.rate')
     tree.should.have.nested.property(
       'propulsion.starboard.fuel.rate.value',
-      1.1111111111111112e-7
+      2.777777777777778e-8
     )
     tree.should.have.nested.property('propulsion.starboard.runTime')
     tree.should.have.nested.property(
@@ -112,6 +190,25 @@ describe('127489 engine parameters Starboard', function () {
     tree.should.have.nested.property(
       'notifications.propulsion.starboard.maintenanceNeeded.value.state',
       'alarm')
+    tree.should.be.validSignalKVesselIgnoringIdentity
+
+    tree = require('./testMapper').toNested(
+      JSON.parse(
+        '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489","description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.1","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure"],"Discrete Status 2": [],"Percent Engine Load": 20,"Percent Engine Torque": 57,"Oil pressure":80}}'
+      )
+    )
+    tree.should.have.nested.property(
+      'notifications.propulsion.starboard.lowOilPressure.value.state',
+      'alarm')
+    tree.should.have.nested.property(
+      'notifications.propulsion.starboard.lowCoolantLevel.value.state',
+      'normal')
+    tree.should.have.nested.property(
+      'notifications.propulsion.starboard.warningLevel1.value.state',
+      'normal')
+    tree.should.have.nested.property(
+      'notifications.propulsion.starboard.maintenanceNeeded.value.state',
+      'normal')
     tree.should.be.validSignalKVesselIgnoringIdentity
   })
 })


### PR DESCRIPTION
Add the following (missing) fields to the test & parser for PGN 127489:

- Fuel Pressure
- Engine coolant pressure
- Total engine hours
- Engine oil temperature

Reference & related issue:

1. http://www.nmea.org/Assets/july%202010%20nmea2000_v1-301_app_b_pgn_field_list.pdf
2. https://github.com/SignalK/n2k-signalk/issues/117