### PR TITLE
fix: exception when an unknown raymarine alarm is received

### DIFF
--- a/raymarine/65288.js
+++ b/raymarine/65288.js
@@ -2,8 +2,16 @@
 module.exports = [
   {
     node: function(n2k) {
-      var alarmName = n2k.fields['Alarm Group'].toLowerCase().replace(/ /g, '') + '.' + n2k.fields['Alarm ID'].replace(/ /g, '');
-      return 'notifications.' + alarmName;
+      var alarmName = n2k.fields['Alarm ID']
+
+      if ( typeof alarmName === 'string' ) {
+        alarmName = alarmName.replace(/ /g, '')
+      } else {
+        alarmName = `unknown${alarmName}`
+      }
+      
+      var path = n2k.fields['Alarm Group'].toLowerCase().replace(/ /g, '')  + '.' + alarmName;
+      return 'notifications.' + path;
     },
     value: function(n2k) {
       var state = n2k.fields['Alarm Status'];
@@ -20,9 +28,14 @@ module.exports = [
         state = 'alarm'
       }
 
+      var alarmName = n2k.fields['Alarm ID']
+
+      if ( typeof alarmName !== 'string' ) {
+        alarmName = `Unknown Seatalk Alarm ${alarmName}`
+      }
 
       return {
-        message: n2k.fields['Alarm ID'],
+        message: alarmName,
         method: method,
         state: state,
         timestamp: n2k.timestamp

--- a/test/65288_seatalk_alarm.js
+++ b/test/65288_seatalk_alarm.js
@@ -52,4 +52,21 @@ describe('65288 Seatalk Alarm', function () {
     // https://github.com/SignalK/specification/issues/281
     // tree.should.be.validSignalKVesselIgnoringIdentity;
   })
+
+  it('unkown alarm type converts', function () {
+    var tree = require('./testMapper').toNested(
+      JSON.parse(
+        '{"timestamp":"2016-10-18T15:54:16.750Z","prio":7,"src":204,"dst":255,"pgn":65288,"description":"Seatalk: Alarm","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Alarm Status":"Alarm condition met and not silenced","Alarm ID":999,"Alarm Group":"Autopilot","Alarm Priority":"0"}}'
+      )
+    )
+    tree.should.have.nested.property(
+      'notifications.autopilot.unknown999.value.state',
+      'alarm'
+    )
+    tree.notifications.autopilot.unknown999.value.message.should.eql(
+      'Unknown Seatalk Alarm 999'
+    )
+    // https://github.com/SignalK/specification/issues/281
+    // tree.should.be.validSignalKVesselIgnoringIdentity;
+  })
 })


### PR DESCRIPTION

Raymarine has added a new alarm type which is not included in canboat. 
