### PR TITLE
Extend pgn 130310 for water temperature

### DIFF
--- a/pgns/130310.js
+++ b/pgns/130310.js
@@ -14,5 +14,14 @@ module.exports = [
     value: function (n2k) {
       return Number(n2k.fields['Atmospheric Pressure'])
     }
+  },
+  {
+     node: 'environment.water.temperature',
+     filter: function (n2k) {
+       return n2k.fields['Water Temperature']
+     },
+     value: function (n2k) {
+	return Number(n2k.fields['Water Temperature'])
+     }
   }
 ]

--- a/test/130310-2.json
+++ b/test/130310-2.json
@@ -31,6 +31,18 @@
       "Atmospheric Pressure": "1018"
     }
   },
+  "130310-water-temperature": {
+   "timestamp":"2018-09-20T00:33:11.411Z",
+   "prio":5,
+   "src":105,
+   "dst":255,
+   "pgn":130310,
+   "description":"Environmental Parameters",
+   "fields":{
+      "SID":0,
+      "Water Temperature":15.50
+    }
+  },
   "130311-outside-temp-humidity-pressure": {
     "timestamp": "2015-01-15-16:25:13.828Z",
     "prio": 5,


### PR DESCRIPTION
Hi,

this PR extends PGN130310. This PGN is also used to transmit the information about water temperature. It has also been successfully tested (see http://www.cruisersforum.com/forums/f134/water-temp-in-ocpn-via-signalk-207730.html#post2726526).

Greeting
free-x