### PR TITLE
fix: support changes to some key names in canboat

### DIFF
--- a/pgns/127488.js
+++ b/pgns/127488.js
@@ -1,23 +1,25 @@
+const {chooseField} = require('../utils.js')
+
 module.exports = [
   {
     node: 'propulsion.port.revolutions',
     filter: function (n2k) {
       return (
-        n2k.fields['Engine Instance'] === 'Single Engine or Dual Engine Port'
+        chooseField(n2k, 'Engine Instance', 'Instance') === 'Single Engine or Dual Engine Port'
       )
     },
     value: function (n2k) {
-      var rpm = Number(n2k.fields['Engine Speed'])
+      var rpm = Number(chooseField(n2k, 'Engine Speed', 'Speed'))
       return rpm / 60.0
     }
   },
   {
     node: 'propulsion.starboard.revolutions',
     filter: function (n2k) {
-      return n2k.fields['Engine Instance'] === 'Dual Engine Starboard'
+      return chooseField(n2k, 'Engine Instance', ['Instance']) === 'Dual Engine Starboard'
     },
     value: function (n2k) {
-      var rpm = Number(n2k.fields['Engine Speed'])
+      var rpm = Number(chooseField(n2k, 'Engine Speed', 'Speed'))
       return rpm / 60.0
     }
   }

--- a/pgns/127489.js
+++ b/pgns/127489.js
@@ -1,7 +1,8 @@
 const util = require('util')
+const {chooseField} = require('../utils.js')
 
 function skEngineId (n2k) {
-  return n2k.fields['Engine Instance'] === 'Single Engine or Dual Engine Port' ? 'port' : 'starboard'
+  return chooseField(n2k, 'Engine Instance', 'Instance') === 'Single Engine or Dual Engine Port' ? 'port' : 'starboard'
 }
 
 function skEngineTitle (n2k) {

--- a/pgns/127506.js
+++ b/pgns/127506.js
@@ -1,3 +1,9 @@
+const {chooseField} = require('../utils.js')
+
+function instance(n2k) {
+  return chooseField(n2k, 'DC Instance', 'Instance')
+}
+
 module.exports = [
   {
     value: function (n2k) {
@@ -9,7 +15,7 @@ module.exports = [
     node: function (n2k) {
       return (
         'electrical.batteries.' +
-        n2k.fields['DC Instance'] +
+        instance(n2k) +
         '.capacity.stateOfCharge'
       )
     }
@@ -19,7 +25,7 @@ module.exports = [
     node: function (n2k) {
       return (
         'electrical.batteries.' +
-        n2k.fields['DC Instance'] +
+        instance(n2k) +
         '.capacity.stateOfHealth'
       )
     }
@@ -39,14 +45,14 @@ module.exports = [
     node: function (n2k) {
       return (
         'electrical.batteries.' +
-        n2k.fields['DC Instance'] +
+        instance(n2k) +
         '.capacity.timeRemaining'
       )
     }
   } /*, {
     source: 'Ripple Voltage',
     node: function(n2k) {
-      return 'electrical.batteries.' + n2k.fields['DC Instance'] + '.voltage.ripple'
+      return 'electrical.batteries.' + instance(n2k) + '.voltage.ripple'
     }
   } */
 ]

--- a/pgns/127508.js
+++ b/pgns/127508.js
@@ -1,9 +1,15 @@
+const {chooseField} = require('../utils.js')
+
+function instance(n2k) {
+  return chooseField(n2k, 'Battery Instance', 'Instance')
+}
+
 module.exports = [
   {
     source: 'Voltage',
     node: function (n2k) {
       return (
-        'electrical.batteries.' + n2k.fields['Battery Instance'] + '.voltage'
+        'electrical.batteries.' + instance(n2k) + '.voltage'
       )
     }
   },
@@ -11,7 +17,7 @@ module.exports = [
     source: 'Current',
     node: function (n2k) {
       return (
-        'electrical.batteries.' + n2k.fields['Battery Instance'] + '.current'
+        'electrical.batteries.' + instance(n2k) + '.current'
       )
     }
   },
@@ -20,7 +26,7 @@ module.exports = [
     node: function (n2k) {
       return (
         'electrical.batteries.' +
-        n2k.fields['Battery Instance'] +
+          instance(n2k) +
         '.temperature'
       )
     }

--- a/pgns/130312.js
+++ b/pgns/130312.js
@@ -1,16 +1,17 @@
 const temperatureMappings = require('../temperatureMappings')
+const {chooseField} = require('../utils.js')
 
 module.exports = [
   {
     node: function (n2k) {
       var temperatureMapping =
-        temperatureMappings[n2k.fields['Temperature Source']]
+          temperatureMappings[chooseField(n2k, 'Temperature Source', 'Source')]
       if (temperatureMapping) {
         return temperatureMapping.path
       }
     },
     instance: function (n2k) {
-      return n2k.fields['Temperature Instance'] + ''
+      return chooseField(n2k, 'Temperature Instance', 'Instance') + ''
     },
     source: 'Actual Temperature'
   }

--- a/pgns/130314.js
+++ b/pgns/130314.js
@@ -1,8 +1,10 @@
+const {chooseField} = require('../utils.js')
+
 module.exports = [
   {
     node: 'environment.outside.pressure',
     filter: function (n2k) {
-      return n2k.fields['Pressure Source'] == 'Atmospheric'
+      return chooseField(n2k, 'Pressure Source', 'Source') == 'Atmospheric'
     },
     value: function (n2k) {
       return Number(n2k.fields['Pressure'])

--- a/test/127488_engine_speed.js
+++ b/test/127488_engine_speed.js
@@ -34,3 +34,36 @@ describe('127488 engine speed Starboard', function () {
     tree.should.be.validSignalKVesselIgnoringIdentity
   })
 })
+
+
+describe('new 127488 engine speed Port', function () {
+  it('complete engine speed sentence converts', function () {
+    var tree = require('./testMapper').toNested(
+      JSON.parse(
+        '{"timestamp":"2015-01-15-16:16:56.749Z","prio":"2","src":"17","dst":"255","pgn":"127488","description":"Engine Parameters, Rapid Update","fields":{"Instance":"Single Engine or Dual Engine Port","Speed":"3190"}}'
+      )
+    )
+    tree.should.have.nested.property('propulsion.port.revolutions')
+    tree.should.have.nested.property(
+      'propulsion.port.revolutions.value',
+      53.166666666666664
+    )
+    tree.should.be.validSignalKVesselIgnoringIdentity
+  })
+})
+
+describe('new 127488 engine speed Starboard', function () {
+  it('complete engine speed sentence converts', function () {
+    var tree = require('./testMapper').toNested(
+      JSON.parse(
+        '{"timestamp":"2015-01-15-16:16:56.749Z","prio":"2","src":"17","dst":"255","pgn":"127488","description":"Engine Parameters, Rapid Update","fields":{"Instance":"Dual Engine Starboard","Speed":"3190"}}'
+      )
+    )
+    tree.should.have.nested.property('propulsion.starboard.revolutions')
+    tree.should.have.nested.property(
+      'propulsion.starboard.revolutions.value',
+      53.166666666666664
+    )
+    tree.should.be.validSignalKVesselIgnoringIdentity
+  })
+})

--- a/test/127488_engine_speed.js
+++ b/test/127488_engine_speed.js
@@ -3,67 +3,40 @@ chai.Should()
 chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
+function generatePGNs(json) {
+  return [json, json.replace('Engine Instance', 'Instance').replace('Engine Speed', 'Speed')]
+}
+
 describe('127488 engine speed Port', function () {
   it('complete engine speed sentence converts', function () {
-    var tree = require('./testMapper').toNested(
-      JSON.parse(
-        '{"timestamp":"2015-01-15-16:16:56.749Z","prio":"2","src":"17","dst":"255","pgn":"127488","description":"Engine Parameters, Rapid Update","fields":{"Engine Instance":"Single Engine or Dual Engine Port","Engine Speed":"3190"}}'
-      )
-    )
-    tree.should.have.nested.property('propulsion.port.revolutions')
-    tree.should.have.nested.property(
-      'propulsion.port.revolutions.value',
-      53.166666666666664
-    )
-    tree.should.be.validSignalKVesselIgnoringIdentity
+    generatePGNs('{"timestamp":"2015-01-15-16:16:56.749Z","prio":"2","src":"17","dst":"255","pgn":"127488","description":"Engine Parameters, Rapid Update","fields":{"Engine Instance":"Single Engine or Dual Engine Port","Engine Speed":"3190"}}')
+      .forEach(pgn => {
+        var tree = require('./testMapper').toNested(
+          JSON.parse(pgn)
+        )
+        tree.should.have.nested.property('propulsion.port.revolutions')
+        tree.should.have.nested.property(
+          'propulsion.port.revolutions.value',
+          53.166666666666664
+        )
+        tree.should.be.validSignalKVesselIgnoringIdentity
+      })
   })
 })
 
 describe('127488 engine speed Starboard', function () {
   it('complete engine speed sentence converts', function () {
-    var tree = require('./testMapper').toNested(
-      JSON.parse(
-        '{"timestamp":"2015-01-15-16:16:56.749Z","prio":"2","src":"17","dst":"255","pgn":"127488","description":"Engine Parameters, Rapid Update","fields":{"Engine Instance":"Dual Engine Starboard","Engine Speed":"3190"}}'
-      )
-    )
-    tree.should.have.nested.property('propulsion.starboard.revolutions')
-    tree.should.have.nested.property(
-      'propulsion.starboard.revolutions.value',
-      53.166666666666664
-    )
-    tree.should.be.validSignalKVesselIgnoringIdentity
-  })
-})
-
-
-describe('new 127488 engine speed Port', function () {
-  it('complete engine speed sentence converts', function () {
-    var tree = require('./testMapper').toNested(
-      JSON.parse(
-        '{"timestamp":"2015-01-15-16:16:56.749Z","prio":"2","src":"17","dst":"255","pgn":"127488","description":"Engine Parameters, Rapid Update","fields":{"Instance":"Single Engine or Dual Engine Port","Speed":"3190"}}'
-      )
-    )
-    tree.should.have.nested.property('propulsion.port.revolutions')
-    tree.should.have.nested.property(
-      'propulsion.port.revolutions.value',
-      53.166666666666664
-    )
-    tree.should.be.validSignalKVesselIgnoringIdentity
-  })
-})
-
-describe('new 127488 engine speed Starboard', function () {
-  it('complete engine speed sentence converts', function () {
-    var tree = require('./testMapper').toNested(
-      JSON.parse(
-        '{"timestamp":"2015-01-15-16:16:56.749Z","prio":"2","src":"17","dst":"255","pgn":"127488","description":"Engine Parameters, Rapid Update","fields":{"Instance":"Dual Engine Starboard","Speed":"3190"}}'
-      )
-    )
-    tree.should.have.nested.property('propulsion.starboard.revolutions')
-    tree.should.have.nested.property(
-      'propulsion.starboard.revolutions.value',
-      53.166666666666664
-    )
-    tree.should.be.validSignalKVesselIgnoringIdentity
+    generatePGNs('{"timestamp":"2015-01-15-16:16:56.749Z","prio":"2","src":"17","dst":"255","pgn":"127488","description":"Engine Parameters, Rapid Update","fields":{"Engine Instance":"Dual Engine Starboard","Engine Speed":"3190"}}')
+      .forEach(pgn => {
+        var tree = require('./testMapper').toNested(
+          JSON.parse(pgn)
+        )
+        tree.should.have.nested.property('propulsion.starboard.revolutions')
+        tree.should.have.nested.property(
+          'propulsion.starboard.revolutions.value',
+          53.166666666666664
+        )
+        tree.should.be.validSignalKVesselIgnoringIdentity
+      })
   })
 })

--- a/test/127489_engine_params.js
+++ b/test/127489_engine_params.js
@@ -3,15 +3,17 @@ chai.Should()
 chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
+function generatePGNs(json) {
+  return [ json, json.replace('Engine Instance', 'Instance') ]
+}
+
 describe('127489 engine parameters Port', function () {
   it('every field in the PGN from the NMEA2000 spec converts', function () {
-    [
-      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489", "description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Single Engine or Dual Engine Port","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80,"Fuel Pressure":504,"Oil temperature":36,"Coolant Pressure":489}}',
-      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489", "description":"Engine Parameters, Dynamic","fields":{"Instance":"Single Engine or Dual Engine Port","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80,"Fuel Pressure":504,"Oil temperature":36,"Coolant Pressure":489}}'
-    ].forEach(pgn => {
-     var tree = require('./testMapper').toNested(
-       JSON.parse(pgn)
-      )
+    generatePGNs('{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489", "description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Single Engine or Dual Engine Port","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80,"Fuel Pressure":504,"Oil temperature":36,"Coolant Pressure":489}}')
+      .forEach(pgn => {
+        var tree = require('./testMapper').toNested(
+          JSON.parse(pgn)
+        )
     
     tree.should.have.nested.property('propulsion.port.oilTemperature')
     tree.should.have.nested.property('propulsion.port.oilTemperature.value', 36)
@@ -55,10 +57,8 @@ describe('127489 engine parameters Port', function () {
   })
 
   it('complete engine params sentence converts', function () {
-    [
-      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489",	"description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Single Engine or Dual Engine Port","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80}}',
-      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489",	"description":"Engine Parameters, Dynamic","fields":{"Instance":"Single Engine or Dual Engine Port","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80}}'
-    ].forEach(pgn => {
+    generatePGNs('{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489",	"description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Single Engine or Dual Engine Port","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80}}')
+      .forEach(pgn => {
     var tree = require('./testMapper').toNested(
       JSON.parse(pgn)
     )
@@ -99,10 +99,8 @@ describe('127489 engine parameters Port', function () {
 
 describe('127489 engine parameters Starboard', function () {
   it('every field in the PGN from the NMEA2000 spec converts', function () {
-    [
-      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489", "description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80,"Fuel Pressure":504,"Oil temperature":36,"Coolant Pressure":489}}',
-      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489", "description":"Engine Parameters, Dynamic","fields":{"Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80,"Fuel Pressure":504,"Oil temperature":36,"Coolant Pressure":489}}'
-    ].forEach(pgn => {
+    generatePGNs('{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489", "description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80,"Fuel Pressure":504,"Oil temperature":36,"Coolant Pressure":489}}')
+    .forEach(pgn => {
     var tree = require('./testMapper').toNested(
       JSON.parse(pgn)
     )
@@ -149,10 +147,8 @@ describe('127489 engine parameters Starboard', function () {
   })
 
   it('complete engine params sentence converts', function () {
-    [
-      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489","description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.1","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":["Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque": 57,"Oil pressure":80}}',
-      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489","description":"Engine Parameters, Dynamic","fields":{"Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.1","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":["Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque": 57,"Oil pressure":80}}'
-    ].forEach(pgn => {
+    generatePGNs('{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489","description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.1","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":["Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque": 57,"Oil pressure":80}}')
+    .forEach(pgn => {
     var tree = require('./testMapper').toNested(
       JSON.parse(pgn)
     )
@@ -203,11 +199,11 @@ describe('127489 engine parameters Starboard', function () {
       'alarm')
     tree.should.be.validSignalKVesselIgnoringIdentity
     })
+  })
 
-    {[
-      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489","description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.1","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure"],"Discrete Status 2": [],"Percent Engine Load": 20,"Percent Engine Torque": 57,"Oil pressure":80}}',
-      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489","description":"Engine Parameters, Dynamic","fields":{"Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.1","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure"],"Discrete Status 2": [],"Percent Engine Load": 20,"Percent Engine Torque": 57,"Oil pressure":80}}'
-    ].forEach(pgn => {
+  it('engine notifications work', function () {
+    generatePGNs('{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489","description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.1","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure"],"Discrete Status 2": [],"Percent Engine Load": 20,"Percent Engine Torque": 57,"Oil pressure":80}}')
+    .forEach(pgn => {
     tree = require('./testMapper').toNested(
       JSON.parse(pgn)
     )
@@ -224,6 +220,6 @@ describe('127489 engine parameters Starboard', function () {
       'notifications.propulsion.starboard.maintenanceNeeded.value.state',
       'normal')
       tree.should.be.validSignalKVesselIgnoringIdentity
-    })}
+    })
   })
 })

--- a/test/127489_engine_params.js
+++ b/test/127489_engine_params.js
@@ -5,12 +5,14 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('127489 engine parameters Port', function () {
   it('every field in the PGN from the NMEA2000 spec converts', function () {
-    var tree = require('./testMapper').toNested(
-      JSON.parse(
-        '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489", "description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Single Engine or Dual Engine Port","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80,"Fuel Pressure":504,"Oil temperature":36,"Coolant Pressure":489}}'
+    [
+      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489", "description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Single Engine or Dual Engine Port","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80,"Fuel Pressure":504,"Oil temperature":36,"Coolant Pressure":489}}',
+      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489", "description":"Engine Parameters, Dynamic","fields":{"Instance":"Single Engine or Dual Engine Port","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80,"Fuel Pressure":504,"Oil temperature":36,"Coolant Pressure":489}}'
+    ].forEach(pgn => {
+     var tree = require('./testMapper').toNested(
+       JSON.parse(pgn)
       )
-    )
-
+    
     tree.should.have.nested.property('propulsion.port.oilTemperature')
     tree.should.have.nested.property('propulsion.port.oilTemperature.value', 36)
     tree.should.have.nested.property('propulsion.port.coolantPressure')
@@ -48,14 +50,17 @@ describe('127489 engine parameters Port', function () {
     tree.should.have.nested.property(
       'notifications.propulsion.port.maintenanceNeeded.value.state',
       'alarm')
-    tree.should.be.validSignalKVesselIgnoringIdentity
+      tree.should.be.validSignalKVesselIgnoringIdentity
+    })
   })
 
   it('complete engine params sentence converts', function () {
+    [
+      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489",	"description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Single Engine or Dual Engine Port","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80}}',
+      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489",	"description":"Engine Parameters, Dynamic","fields":{"Instance":"Single Engine or Dual Engine Port","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80}}'
+    ].forEach(pgn => {
     var tree = require('./testMapper').toNested(
-      JSON.parse(
-        '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489",	"description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Single Engine or Dual Engine Port","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80}}'
-      )
+      JSON.parse(pgn)
     )
     tree.should.have.nested.property('propulsion.port.temperature')
     tree.should.have.nested.property('propulsion.port.temperature.value', 29.85)
@@ -88,17 +93,20 @@ describe('127489 engine parameters Port', function () {
       'notifications.propulsion.port.maintenanceNeeded.value.state',
       'alarm')
     tree.should.be.validSignalKVesselIgnoringIdentity
+    })
   })
 })
 
 describe('127489 engine parameters Starboard', function () {
   it('every field in the PGN from the NMEA2000 spec converts', function () {
+    [
+      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489", "description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80,"Fuel Pressure":504,"Oil temperature":36,"Coolant Pressure":489}}',
+      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489", "description":"Engine Parameters, Dynamic","fields":{"Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80,"Fuel Pressure":504,"Oil temperature":36,"Coolant Pressure":489}}'
+    ].forEach(pgn => {
     var tree = require('./testMapper').toNested(
-      JSON.parse(
-        '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489", "description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.4","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":[ "Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque":57,"Oil pressure":80,"Fuel Pressure":504,"Oil temperature":36,"Coolant Pressure":489}}'
-      )
+      JSON.parse(pgn)
     )
-
+      
     tree.should.have.nested.property('propulsion.starboard.oilTemperature')
     tree.should.have.nested.property('propulsion.starboard.oilTemperature.value', 36)
     tree.should.have.nested.property('propulsion.starboard.coolantPressure')
@@ -137,13 +145,16 @@ describe('127489 engine parameters Starboard', function () {
       'notifications.propulsion.starboard.maintenanceNeeded.value.state',
       'alarm')
     tree.should.be.validSignalKVesselIgnoringIdentity
+    })
   })
 
   it('complete engine params sentence converts', function () {
+    [
+      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489","description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.1","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":["Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque": 57,"Oil pressure":80}}',
+      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489","description":"Engine Parameters, Dynamic","fields":{"Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.1","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":["Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque": 57,"Oil pressure":80}}'
+    ].forEach(pgn => {
     var tree = require('./testMapper').toNested(
-      JSON.parse(
-        '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489","description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.1","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure","Low Coolant Level"],"Discrete Status 2":["Warning Level 1","Maintenance Needed"],"Percent Engine Load": 20,"Percent Engine Torque": 57,"Oil pressure":80}}'
-      )
+      JSON.parse(pgn)
     )
     tree.should.have.nested.property('propulsion.starboard.temperature')
     tree.should.have.nested.property(
@@ -191,11 +202,14 @@ describe('127489 engine parameters Starboard', function () {
       'notifications.propulsion.starboard.maintenanceNeeded.value.state',
       'alarm')
     tree.should.be.validSignalKVesselIgnoringIdentity
+    })
 
+    {[
+      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489","description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.1","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure"],"Discrete Status 2": [],"Percent Engine Load": 20,"Percent Engine Torque": 57,"Oil pressure":80}}',
+      '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489","description":"Engine Parameters, Dynamic","fields":{"Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.1","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure"],"Discrete Status 2": [],"Percent Engine Load": 20,"Percent Engine Torque": 57,"Oil pressure":80}}'
+    ].forEach(pgn => {
     tree = require('./testMapper').toNested(
-      JSON.parse(
-        '{"timestamp":"2015-01-15-16:25:14.952Z","prio":"2","src":"17","dst":"255","pgn":"127489","description":"Engine Parameters, Dynamic","fields":{"Engine Instance":"Dual Engine Starboard","Temperature":"29.85","Alternator Potential":"12.60","Fuel Rate":"0.1","Total Engine hours":"309960","Discrete Status 1":["Low Oil Pressure"],"Discrete Status 2": [],"Percent Engine Load": 20,"Percent Engine Torque": 57,"Oil pressure":80}}'
-      )
+      JSON.parse(pgn)
     )
     tree.should.have.nested.property(
       'notifications.propulsion.starboard.lowOilPressure.value.state',
@@ -209,6 +223,7 @@ describe('127489 engine parameters Starboard', function () {
     tree.should.have.nested.property(
       'notifications.propulsion.starboard.maintenanceNeeded.value.state',
       'normal')
-    tree.should.be.validSignalKVesselIgnoringIdentity
+      tree.should.be.validSignalKVesselIgnoringIdentity
+    })}
   })
 })

--- a/test/127506_dc_detailed_status.js
+++ b/test/127506_dc_detailed_status.js
@@ -1,13 +1,16 @@
 var chai = require('chai')
 chai.Should()
 chai.use(require('chai-things'))
+chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('127506 dc detailed status', function () {
   it('complete sentence converts', function () {
+    [
+      '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"DC Instance":1,"State of Charge":60,"State of Health":99,"Time Remaining": 600, "Ripple Voltage": 10.9, "SID":0}}',
+      '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"Instance":1,"State of Charge":60,"State of Health":99,"Time Remaining": 600, "Ripple Voltage": 10.9, "SID":0}}'
+    ].forEach(pgn => {
     var tree = require('./testMapper').toNested(
-      JSON.parse(
-        '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"DC Instance":1,"State of Charge":60,"State of Health":99,"Time Remaining": 600, "Ripple Voltage": 10.9, "SID":0}}'
-      )
+      JSON.parse(pgn)
     )
     tree.should.have.nested.property(
       'electrical.batteries.1.capacity.stateOfCharge.value',
@@ -22,10 +25,13 @@ describe('127506 dc detailed status', function () {
       36000
     )
     // tree.should.have.nested.property('electrical.batteries.1.voltage.ripple.value', 10.9);
-    tree.should.be.validSignalKVesselIgnoringIdentity
+      tree.should.be.validSignalKVesselIgnoringIdentity
+    })
   })
   it('null timeRemaining converts', function () {
-    var pgn = '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"DC Instance":1,"SID":0}}'
+    ['{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"DC Instance":1,"SID":0}}',
+     '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"Instance":1,"SID":0}}'
+    ].forEach(pgn => {
     var delta = require('./testMapper').toDelta(JSON.parse(pgn))
     tree = require('./testMapper').toNested(JSON.parse(pgn))
 
@@ -39,5 +45,6 @@ describe('127506 dc detailed status', function () {
       'electrical.batteries.1.capacity.timeRemaining.value',
       null
     )
+    })
   })
 })

--- a/test/127506_dc_detailed_status.js
+++ b/test/127506_dc_detailed_status.js
@@ -3,12 +3,13 @@ chai.Should()
 chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
+function generatePGNs(json) {
+  return [ json, json.replace('DC Instance', 'Instance') ]
+}
 describe('127506 dc detailed status', function () {
   it('complete sentence converts', function () {
-    [
-      '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"DC Instance":1,"State of Charge":60,"State of Health":99,"Time Remaining": 600, "Ripple Voltage": 10.9, "SID":0}}',
-      '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"Instance":1,"State of Charge":60,"State of Health":99,"Time Remaining": 600, "Ripple Voltage": 10.9, "SID":0}}'
-    ].forEach(pgn => {
+    generatePGNs('{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"DC Instance":1,"State of Charge":60,"State of Health":99,"Time Remaining": 600, "Ripple Voltage": 10.9, "SID":0}}')
+    .forEach(pgn => {
     var tree = require('./testMapper').toNested(
       JSON.parse(pgn)
     )
@@ -29,9 +30,8 @@ describe('127506 dc detailed status', function () {
     })
   })
   it('null timeRemaining converts', function () {
-    ['{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"DC Instance":1,"SID":0}}',
-     '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"Instance":1,"SID":0}}'
-    ].forEach(pgn => {
+    generatePGNs('{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"DC Instance":1,"SID":0}}')
+    .forEach(pgn => {
     var delta = require('./testMapper').toDelta(JSON.parse(pgn))
     tree = require('./testMapper').toNested(JSON.parse(pgn))
 

--- a/test/127508_battery_voltage.js
+++ b/test/127508_battery_voltage.js
@@ -1,13 +1,16 @@
 var chai = require('chai')
 chai.Should()
 chai.use(require('chai-things'))
+chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('127508 battery voltage', function () {
   it('complete sentence converts', function () {
+    [
+      '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127508,"description":"Battery Status","fields":{"Battery Instance":1,"Voltage":13.11,"Current":5.6,"Temperature": 299, "SID":0}}',
+      '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127508,"description":"Battery Status","fields":{"Instance":1,"Voltage":13.11,"Current":5.6,"Temperature": 299, "SID":0}}'
+    ].forEach(pgn => {
     var tree = require('./testMapper').toNested(
-      JSON.parse(
-        '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127508,"description":"Battery Status","fields":{"Battery Instance":1,"Voltage":13.11,"Current":5.6,"Temperature": 299, "SID":0}}'
-      )
+      JSON.parse(pgn)
     )
     tree.should.have.nested.property(
       'electrical.batteries.1.voltage.value',
@@ -22,5 +25,6 @@ describe('127508 battery voltage', function () {
       299
     )
     tree.should.be.validSignalKVesselIgnoringIdentity
+    })
   })
 })

--- a/test/127508_battery_voltage.js
+++ b/test/127508_battery_voltage.js
@@ -5,10 +5,9 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('127508 battery voltage', function () {
   it('complete sentence converts', function () {
-    [
-      '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127508,"description":"Battery Status","fields":{"Battery Instance":1,"Voltage":13.11,"Current":5.6,"Temperature": 299, "SID":0}}',
-      '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127508,"description":"Battery Status","fields":{"Instance":1,"Voltage":13.11,"Current":5.6,"Temperature": 299, "SID":0}}'
-    ].forEach(pgn => {
+    const json = '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127508,"description":"Battery Status","fields":{"Battery Instance":1,"Voltage":13.11,"Current":5.6,"Temperature": 299, "SID":0}}'
+    const pgns = [ json, json.replace('Battery Instance', 'Instance') ]
+    pgns.forEach(pgn => {
     var tree = require('./testMapper').toNested(
       JSON.parse(pgn)
     )

--- a/test/130310-2.json
+++ b/test/130310-2.json
@@ -112,6 +112,19 @@
       "Temperature Source": "Heating System Temperature"
     }
   },
+  "130312-heatingsystem-novalue-new": {
+    "timestamp": "2015-01-15-16:25:12.126Z",
+    "prio": 5,
+    "src": 41,
+    "dst": 255,
+    "pgn": 130312,
+    "description": "Temperature",
+    "fields": {
+      "SID": 112,
+      "Instance": 0,
+      "Source": "Heating System Temperature"
+    }
+  },
   "130312-engineroomtemp": {
     "timestamp": "2015-01-15-16:15:18.127Z",
     "prio": "5",
@@ -123,6 +136,20 @@
       "SID": "179",
       "Temperature Instance": "2",
       "Temperature Source": "Engine Room Temperature",
+      "Actual Temperature": "7.76"
+    }
+  },
+  "130312-engineroomtemp-new": {
+    "timestamp": "2015-01-15-16:15:18.127Z",
+    "prio": "5",
+    "src": "41",
+    "dst": "255",
+    "pgn": "130312",
+    "description": "Temperature",
+    "fields": {
+      "SID": "179",
+      "Instance": "2",
+      "Source": "Engine Room Temperature",
       "Actual Temperature": "7.76"
     }
   },
@@ -140,7 +167,35 @@
       "Actual Temperature": "13.18"
     }
   },
+  "130312-insidetemp-new": {
+    "timestamp": "2015-01-15-16:15:18.129Z",
+    "prio": "5",
+    "src": "41",
+    "dst": "255",
+    "pgn": "130312",
+    "description": "Temperature",
+    "fields": {
+      "SID": "179",
+      "Instance": "3",
+      "Source": "Inside Temperature",
+      "Actual Temperature": "13.18"
+    }
+  },
   "130312-maincabin": {
+    "timestamp": "2015-01-15-16:15:18.131Z",
+    "prio": "5",
+    "src": "41",
+    "dst": "255",
+    "pgn": "130312",
+    "description": "Temperature",
+    "fields": {
+      "SID": "179",
+      "Temperature Instance": "4",
+      "Temperature Source": "Main Cabin Temperature",
+      "Actual Temperature": "16.93"
+    }
+  },
+  "130312-maincabin-new": {
     "timestamp": "2015-01-15-16:15:18.131Z",
     "prio": "5",
     "src": "41",
@@ -168,6 +223,20 @@
       "Actual Temperature": "70"
     }
   },
+  "130312-engineroomtemp-new": {
+    "timestamp": "2015-01-15-16:15:18.136Z",
+    "prio": "5",
+    "src": "41",
+    "dst": "255",
+    "pgn": "130312",
+    "description": "Temperature",
+    "fields": {
+      "SID": "179",
+      "Instance": "5",
+      "Source": "Engine Room Temperature",
+      "Actual Temperature": "70"
+    }
+  },
   "130312-engineroomtemp-novalue": {
     "timestamp": "2015-01-15-16:15:18.136Z",
     "prio": "5",
@@ -181,7 +250,34 @@
       "Temperature Source": "Engine Room Temperature"
     }
   },
+  "130312-engineroomtemp-novalue-new": {
+    "timestamp": "2015-01-15-16:15:18.136Z",
+    "prio": "5",
+    "src": "41",
+    "dst": "255",
+    "pgn": "130312",
+    "description": "Temperature",
+    "fields": {
+      "SID": "179",
+      "Instance": "5",
+      "Source": "Engine Room Temperature"
+    }
+  },
   "130312-outsidetemp": {
+    "timestamp": "2015-01-15-16:15:18.371Z",
+    "prio": "5",
+    "src": "130",
+    "dst": "255",
+    "pgn": "130312",
+    "description": "Temperature",
+    "fields": {
+      "SID": "14",
+      "Temperature Instance": "0",
+      "Temperature Source": "Outside Temperature",
+      "Actual Temperature": "7.84"
+    }
+  },
+  "130312-outsidetemp-new": {
     "timestamp": "2015-01-15-16:15:18.371Z",
     "prio": "5",
     "src": "130",
@@ -205,6 +301,19 @@
     "fields": {
       "Temperature Instance": "0",
       "Temperature Source": "Sea Temperature",
+      "Actual Temperature": "15.2"
+    }
+  },
+  "130312-seatemp-new": {
+    "timestamp": "2015-01-15-16:15:19.628Z",
+    "prio": "5",
+    "src": "36",
+    "dst": "255",
+    "pgn": "130312",
+    "description": "Temperature",
+    "fields": {
+      "Instance": "0",
+      "Source": "Sea Temperature",
       "Actual Temperature": "15.2"
     }
   }

--- a/test/130314_pressure.js
+++ b/test/130314_pressure.js
@@ -5,10 +5,9 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('130314_pressure', function () {
   it('complete sentence converts', function () {
-    [
-      '{"timestamp":"2016-04-09T16:41:39.364Z","prio":5,"src":28,"dst":255,"pgn":130314,"description":"Actual Pressure","fields":{"SID":0,"Pressure Instance":0,"Pressure Source":"Atmospheric","Pressure":100578}}',
-      '{"timestamp":"2016-04-09T16:41:39.364Z","prio":5,"src":28,"dst":255,"pgn":130314,"description":"Actual Pressure","fields":{"SID":0,"Instance":0,"Source":"Atmospheric","Pressure":100578}}'
-    ].forEach(pgn => {
+    const json = '{"timestamp":"2016-04-09T16:41:39.364Z","prio":5,"src":28,"dst":255,"pgn":130314,"description":"Actual Pressure","fields":{"SID":0,"Pressure Instance":0,"Pressure Source":"Atmospheric","Pressure":100578}}'
+    const pgns = [ json, json.replace('Pressure Instance', 'Pressure') ]
+    pgns.forEach(pgn => {
     var tree = require('./testMapper').toNested(
       JSON.parse(pgn)
     )

--- a/test/130314_pressure.js
+++ b/test/130314_pressure.js
@@ -5,12 +5,15 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('130314_pressure', function () {
   it('complete sentence converts', function () {
+    [
+      '{"timestamp":"2016-04-09T16:41:39.364Z","prio":5,"src":28,"dst":255,"pgn":130314,"description":"Actual Pressure","fields":{"SID":0,"Pressure Instance":0,"Pressure Source":"Atmospheric","Pressure":100578}}',
+      '{"timestamp":"2016-04-09T16:41:39.364Z","prio":5,"src":28,"dst":255,"pgn":130314,"description":"Actual Pressure","fields":{"SID":0,"Instance":0,"Source":"Atmospheric","Pressure":100578}}'
+    ].forEach(pgn => {
     var tree = require('./testMapper').toNested(
-      JSON.parse(
-        '{"timestamp":"2016-04-09T16:41:39.364Z","prio":5,"src":28,"dst":255,"pgn":130314,"description":"Actual Pressure","fields":{"SID":0,"Pressure Instance":0,"Pressure Source":"Atmospheric","Pressure":100578}}'
-      )
+      JSON.parse(pgn)
     )
     tree.should.have.nested.property('environment.outside.pressure.value', 100578)
-    tree.should.be.validSignalKVesselIgnoringIdentity
+      tree.should.be.validSignalKVesselIgnoringIdentity
+    })
   })
 })

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,8 @@
+
+module.exports = {
+  chooseField: (n2k, field1, field2) => {
+    let res = typeof n2k.fields[field1] === 'undefined' ? n2k.fields[field2] : n2k.fields[field1]
+    //console.log(`chooseField ${typeof n2k.fields[field1]} '${field1}' '${field2}' ${res} ${JSON.stringify(n2k.fields)}`)
+    return res
+  }
+}


### PR DESCRIPTION

canboat has some changes to key names, like 'DC Instance' was changed to 'Instance'.

Since there's not versioning, this change makes to we can support the old and new keys.