### PR TITLE
fix: bug parsing PGN 129025 without position data

### DIFF
--- a/pgns/129025.js
+++ b/pgns/129025.js
@@ -6,6 +6,12 @@ module.exports = [
         latitude: Number(n2k.fields.Latitude)
       }
     },
+    filter: function (n2k) {
+      return (
+        typeof n2k.fields['Longitude'] !== 'undefined' &&
+        typeof n2k.fields['Latitude'] !== 'undefined'
+      )
+    },
     node: 'navigation.position'
   }
 ]

--- a/test/129025_position.js
+++ b/test/129025_position.js
@@ -6,6 +6,14 @@ var msg = JSON.parse(
   '{"timestamp":"2013-10-08-15:47:28.264Z","prio":"2","src":"2","dst":"255","pgn":"129025","description":"Position, Rapid Update","fields":{"Latitude":"60.1445540","Longitude":"24.7921348"}}'
 )
 
+// Seen in the wild - Original sentence: $PCDIN,01F801,5B26371E,01,FFFFFF7FFFFFFF7F*2C
+var messageWithoutPosition = {
+  "pgn":129025,
+  "timestamp":"1970-01-18T16:47:11.134Z","src":1,"dst":255,"prio":0,
+  "fields":{},
+  "description":"Position, Rapid Update"
+}
+
 describe('129025 Position, rapid update ', function () {
   it('complete sentence converts to tree', function () {
     var tree = require('./testMapper').toNested(msg)
@@ -17,5 +25,10 @@ describe('129025 Position, rapid update ', function () {
   it('complete sentence produces valid delta', function () {
     var delta = require('./testMapper').toDelta(msg)
     delta.should.be.validSignalKDelta
+  })
+
+  it('sentence without valid position data is still valid', () => {
+    var tree = require('./testMapper').toNested(messageWithoutPosition)
+    tree.should.be.validSignalKVesselIgnoringIdentity
   })
 })


### PR DESCRIPTION
When the position 'rapid update' pgn is received, it may not contain a
valid latitude/longitude. When that happens, we should still generate
valid SignalK.

Before this fix, we would generate `"value":{"longitude":null,"latitude":null}}` which is invalid.