### PR TITLE
fix: generate UTC timestamps with Z

### DIFF
--- a/n2kMapper.js
+++ b/n2kMapper.js
@@ -30,7 +30,8 @@ var toDelta = function (n2k, state) {
           timestamp:
             n2k.timestamp.substring(0, 10) +
             'T' +
-            n2k.timestamp.substring(11, n2k.timestamp.length),
+            n2k.timestamp.substring(11, n2k.timestamp.length) +
+            'Z',
           values: toValuesArray(theMappings, n2k, src_state)
         }
       ]


### PR DESCRIPTION
the Z was missing from the timestamps that are generated from
strings in the analyzer json output