### PR TITLE
fix: 130311 atmospheric pressure

### DIFF
--- a/pgns/130311.js
+++ b/pgns/130311.js
@@ -33,8 +33,7 @@ module.exports = [
       return n2k.fields['Atmospheric Pressure']
     },
     value: function (n2k) {
-      var hpa = Number(n2k.fields['Atmospheric Pressure'])
-      return hpa * 100.0
+      return Number(n2k.fields['Atmospheric Pressure'])
     }
   }
 ]

--- a/test/130310-2.json
+++ b/test/130310-2.json
@@ -67,7 +67,7 @@
     },
     "testExpectConvertedValues": {
       "environment.outside.temperature": 8.05,
-      "environment.outside.pressure": 10180000,
+      "environment.outside.pressure": 101800,
       "environment.outside.humidity": 0.72772
     }
   },


### PR DESCRIPTION
Conversion to Pascals seems to be off, see https://github.com/SignalK/signalk-server-node/issues/670.