### PR TITLE
style: Remove duplicate Heat Index Temp

### DIFF
--- a/temperatureMappings.js
+++ b/temperatureMappings.js
@@ -57,9 +57,6 @@ module.exports = {
   'Heat Index Temperature': {
     path: 'environment.outside.heatIndexTemperature'
   },
-  'Heat Index Temperature': {
-    path: 'environment.outside.heatIndexTemperature'
-  },
   'Freezer Temperature': {
     path: 'environment.inside.freezer.temperature'
   },


### PR DESCRIPTION
Looks like there was a duplicate in `temperatureMappings.js` of

```javascript
  'Heat Index Temperature': {
    path: 'environment.outside.heatIndexTemperature'
  },
```

so I removed one of them.