### PR TITLE
feature: adds support for user defined temperatures

### DIFF
--- a/pgns/130312.js
+++ b/pgns/130312.js
@@ -15,6 +15,8 @@ module.exports = [
         } else if (temperatureMapping.path) {
           return temperatureMapping.path
         }
+      } else {
+        return `generic.temperatures.userDefined${n2k.fields['Source']}.${n2k.fields['Instance']}.temperature`
       }
     },
     instance: function (n2k) {

--- a/test/130310-2.json
+++ b/test/130310-2.json
@@ -473,6 +473,7 @@
     }
   },
   "130312-userDefined129": {
+    "notInSpec": true,
     "timestamp": "2015-01-15-16:15:19.628Z",
     "prio": "5",
     "src": "36",

--- a/test/130310-2.json
+++ b/test/130310-2.json
@@ -471,5 +471,21 @@
     "testExpectConvertedValues": {
       "environment.inside.refrigerator.temperature": 15.2
     }
+  },
+  "130312-userDefined129": {
+    "timestamp": "2015-01-15-16:15:19.628Z",
+    "prio": "5",
+    "src": "36",
+    "dst": "255",
+    "pgn": "130312",
+    "description": "Temperature",
+    "fields": {
+      "Instance": "0",
+      "Source": "129",
+      "Actual Temperature": "15.2"
+    },
+    "testExpectConvertedValues": {
+      "generic.temperatures.userDefined129.0.temperature": 15.2
+    }
   }
 }

--- a/test/13031_temperature.js
+++ b/test/13031_temperature.js
@@ -42,9 +42,11 @@ describe('Temperature: ', function () {
         }
       )
 
-      var fullDoc = full.retrieve()
-      fullDoc.vessels['urn:mrn:imo:mmsi:230099999'].mmsi = '230099999'
-      fullDoc.should.be.validSignalK
+      if(!testCase.notInSpec || testCase.notInSpec == false){
+        var fullDoc = full.retrieve()
+        fullDoc.vessels['urn:mrn:imo:mmsi:230099999'].mmsi = '230099999'
+        fullDoc.should.be.validSignalK
+      }
     })
   })
 


### PR DESCRIPTION
This adds support for those temperature sources not specifically defined by NMEA.
NMEA allows for a user defined temperature source ranging from 129-252.

The new path will be generic.temperatures.userDefined<###>.<instance>.temperature

The test has been added but will fail until generic is added to the specification.