### PR TITLE
fix: Refrigeration spelling

### DIFF
--- a/pgns/130312.js
+++ b/pgns/130312.js
@@ -16,7 +16,7 @@ module.exports = [
           return temperatureMapping.path
         }
       } else {
-        return `generic.temperatures.userDefined${n2k.fields['Source']}.${n2k.fields['Instance']}.temperature`
+        return `generic.temperatures.userDefined${n2k.fields['Source'].replace(/\ /g, '_')}.${n2k.fields['Instance']}.temperature`
       }
     },
     instance: function (n2k) {

--- a/temperatureMappings.js
+++ b/temperatureMappings.js
@@ -39,6 +39,11 @@ module.exports = {
     path: 'tanks.baitWell.default.temperature',
     pathWithIndex: 'tanks.baitWell.<index>.temperature'
   },
+  'Refrigeration Temperature': {
+    path: 'environment.inside.refrigerator.temperature'
+  },
+  //leave old misspelled version in place just in case
+  //https://github.com/canboat/canboat/issues/234
   'Refridgeration Temperature': {
     path: 'environment.inside.refrigerator.temperature'
   },

--- a/test/130310-2.json
+++ b/test/130310-2.json
@@ -504,5 +504,22 @@
     "testExpectConvertedValues": {
       "generic.temperatures.userDefined129.0.temperature": 15.2
     }
+  },
+  "130312-userDefined-with-space": {
+    "notInSpec": true,
+    "timestamp": "2015-01-15-16:15:19.628Z",
+    "prio": "5",
+    "src": "36",
+    "dst": "255",
+    "pgn": "130312",
+    "description": "Temperature",
+    "fields": {
+      "Instance": "0",
+      "Source": "Source with a space",
+      "Actual Temperature": "15.2"
+    },
+    "testExpectConvertedValues": {
+      "generic.temperatures.userDefinedSource_with_a_space.0.temperature": 15.2
+    }
   }
 }

--- a/test/130310-2.json
+++ b/test/130310-2.json
@@ -472,6 +472,22 @@
       "environment.inside.refrigerator.temperature": 15.2
     }
   },
+  "130312-frige-new-old-spelling": {
+    "timestamp": "2015-01-15-16:15:19.628Z",
+    "prio": "5",
+    "src": "36",
+    "dst": "255",
+    "pgn": "130312",
+    "description": "Temperature",
+    "fields": {
+      "Instance": "0",
+      "Source": "Refrigeration Temperature",
+      "Actual Temperature": "15.2"
+    },
+    "testExpectConvertedValues": {
+      "environment.inside.refrigerator.temperature": 15.2
+    }
+  },
   "130312-userDefined129": {
     "notInSpec": true,
     "timestamp": "2015-01-15-16:15:19.628Z",

--- a/test/13031_temperature.js
+++ b/test/13031_temperature.js
@@ -29,7 +29,7 @@ describe('Temperature: ', function () {
           )
           expectedValueFound.length.should.equal(
             1,
-            `Expected value ${expectedValuePath} not found.`
+            `Expected value ${expectedValuePath} not found in ${JSON.stringify(delta, null, 2)}`
           )
           expectedValueFound[0].value.should.equal(
             testCase['testExpectConvertedValues'][expectedValuePath],


### PR DESCRIPTION
Adjust to change in spelling in canboat and in case we can not find a mapping for a user defined temperature source replace spaces with underscores in the SK path.