### PR TITLE
fix: 130306 direction output

### DIFF
--- a/pgns/130306.js
+++ b/pgns/130306.js
@@ -39,7 +39,7 @@ module.exports = [
   },
   {
     source: 'Wind Angle',
-    node: 'environment.wind.directionGround',
+    node: 'environment.wind.directionTrue',
     filter: function (n2k) {
       return n2k.fields['Reference'] === 'True (ground referenced to North)'
     }

--- a/test/130306_wind_data.js
+++ b/test/130306_wind_data.js
@@ -80,10 +80,10 @@ describe('130306 Wind Data', function () {
       4.82
     )
     tree.should.have.nested.property(
-      'environment.wind.directionGround.value',
+      'environment.wind.directionTrue.value',
       218.6
     )
-    //tree.should.be.validSignalKVesselIgnoringIdentity
+    tree.should.be.validSignalKVesselIgnoringIdentity
   })
 
   it('Magnetic Ground sentence converts', function () {


### PR DESCRIPTION
There is not directionGround in the current SK spec. Instead
there are directionTrue and directionMagnetic. Note that True
refers here to same thing as in heading: what the number is
referenced from. Both direction paths are relative to Ground.