### PR TITLE
fix: pgn 130312 userDefined temperature source handling

### DIFF
--- a/pgns/130312.js
+++ b/pgns/130312.js
@@ -16,7 +16,7 @@ module.exports = [
           return temperatureMapping.path
         }
       } else {
-        return `generic.temperatures.userDefined${n2k.fields['Source'].replace(/\ /g, '_')}.${n2k.fields['Instance']}.temperature`
+        return `generic.temperatures.userDefined${n2k.fields['Source'].toString().replace(/\ /g, '_')}.${n2k.fields['Instance']}.temperature`
       }
     },
     instance: function (n2k) {


### PR DESCRIPTION
I'm not certain when this changed but the PGN field Source is now an int
instead of string. We are trying to replace the sourc with the instance
but that now throws an error "TypeError: n2k.fields.Source.replace is not a function".

This fix converts the Source int to string so that it can be replaced.

Example data

{"canId":368904234,"prio":5,"src":42,"dst":255,"pgn":130312,"time":"21:04:58.247","input":["21:04:58.247 R 15FD082A 7B 00 83 30 71 FF FF FF"],"fields":{"SID":123,"Instance":0,"Source":131,"Actual Temperature":289.76},"description":"Temperature","timestamp":"2022-04-08T21:04:58.402Z"}