### PR TITLE
feature: add support for Raymarine SeaTalk-STNG-Converter AP PGNs

### DIFF
--- a/raymarine/126720.js
+++ b/raymarine/126720.js
@@ -27,7 +27,7 @@ module.exports =  [
         return 'auto';
       }
       else {
-        console.log('n2k-signalk 126720.js undefined AP state found. n2k data: ' + JSON.stringify(n2k))
+        console.log('Unknown PGN 126720 AP state found.')
         return;
       }
     }

--- a/raymarine/126720.js
+++ b/raymarine/126720.js
@@ -1,20 +1,35 @@
 
 module.exports =  [
   {
+    // filters for SmartPilot behind Seatalk-STNG-Converter
+    filter: function(n2k) {
+      return (
+        n2k.description === 'Seatalk1: Pilot Mode' &&
+        n2k.fields['Manufacturer Code'] === 'Raymarine' &&
+        typeof n2k.fields['Pilot Mode'] !== 'undefined' &&
+        typeof n2k.fields['Sub Mode'] !== 'undefined'
+      )
+    },
     node: 'steering.autopilot.state',
     value: function(n2k) {
       var mode = Number(n2k.fields['Pilot Mode']);
       var subMode = Number(n2k.fields['Sub Mode']);
-      if ( mode == 0 && subMode == 0 )
+      if ( (mode == 0 || mode == 64 || mode == 68 || mode == 72) && subMode == 0 ) {
         return 'standby';
-      else if ( mode == 70 && subMode == 0 )  // is sub mode 1 True wind & mode 0 apparent wind?
+      }
+      else if ( mode == 70 && ( subMode == 0 || subMode == 4 || subMode == 8 || subMode ==12 ) ) { // submodes: 0=on course,  4=off course pt/stb, 8=wind shift, submode 12 tbd 
         return 'wind';
-      else if ( (mode == 74 || mode == 129) && subMode == 1 ) // not yet validated
+      }
+      else if ( (mode == 74  && subMode == 0 ) {
         return 'route';
-      else if ( mode == 66 && subMode == 0 )
+      }
+      else if ( mode == 66 && ( subMode == 0 || subMode == 4 ) ) { //subMode 4 means offcourse
         return 'auto';
-      else  // mode 68 or 64 are valide
-        return 'standby';
+      }
+      else {
+        console.log('n2k-signalk 126720.js undefined AP state found. n2k data: ' + JSON.stringify(n2k))
+        return;
+      }
     }
-  }
+  },
 ]

--- a/raymarine/126720.js
+++ b/raymarine/126720.js
@@ -21,7 +21,7 @@ module.exports =  [
       else if ( mode == 70 && ( subMode == 0 || subMode == 4 || subMode == 8 || subMode ==12 ) ) { // submodes: 0=on course,  4=off course pt/stb, 8=wind shift, submode 12 tbd 
         return 'wind';
       }
-      else if ( (mode == 74  && subMode == 0 ) {
+      else if (mode == 74  && subMode == 0 ) {
         return 'route';
       }
       else if ( mode == 66 && ( subMode == 0 || subMode == 4 ) ) { //subMode 4 means offcourse

--- a/raymarine/126720.js
+++ b/raymarine/126720.js
@@ -1,0 +1,20 @@
+
+module.exports =  [
+  {
+    node: 'steering.autopilot.state',
+    value: function(n2k) {
+      var mode = Number(n2k.fields['Pilot Mode']);
+      var subMode = Number(n2k.fields['Sub Mode']);
+      if ( mode == 0 && subMode == 0 )
+        return 'standby';
+      else if ( mode == 70 && subMode == 0 )  // is sub mode 1 True wind & mode 0 apparent wind?
+        return 'wind';
+      else if ( (mode == 74 || mode == 129) && subMode == 1 ) // not yet validated
+        return 'route';
+      else if ( mode == 66 && subMode == 0 )
+        return 'auto';
+      else  // mode 68 or 64 are valide
+        return 'standby';
+    }
+  }
+]

--- a/raymarine/126720.js
+++ b/raymarine/126720.js
@@ -1,3 +1,4 @@
+const debug = require('debug')('n2k-signalk-126720')
 
 module.exports =  [
   {
@@ -27,7 +28,7 @@ module.exports =  [
         return 'auto';
       }
       else {
-        console.log('Unknown PGN 126720 AP state found.')
+        debug('Unknown PGN 126720 AP state found - Mode: ' + mode + ', SubMode: ' + subMode)
         return;
       }
     }

--- a/raymarine/65359.js
+++ b/raymarine/65359.js
@@ -1,16 +1,20 @@
-// need to check what happens when True heading is configured in the AP
+// PGN 65359 Seatalk: Pilot Heading
 module.exports = [
     {
-      node: 'navigation.headingtrue',
+      node: 'navigation.headingTrue',
       filter: function(n2k) {
-        return n2k.fields['Heading True']
+        return (
+          n2k.description === 'Seatalk: Pilot Heading' &&
+          typeof n2k.fields['Heading True'] !== 'undefined'
+        )
       },
       source: 'Heading True'
     },
     {
       node: 'navigation.headingMagnetic',
       filter: function(n2k) {
-        return n2k.fields['Heading Magnetic']
+        return n2k.description === 'Seatalk: Pilot Heading' &&
+        typeof n2k.fields['Heading Magnetic'] !== 'undefined'
       },
       source: 'Heading Magnetic'
     }

--- a/raymarine/65359.js
+++ b/raymarine/65359.js
@@ -1,0 +1,17 @@
+// need to check what happens when True heading is configured in the AP
+module.exports = [
+    {
+      node: 'navigation.headingtrue',
+      filter: function(n2k) {
+        return n2k.fields['Heading True']
+      },
+      source: 'Heading True'
+    },
+    {
+      node: 'navigation.headingMagnetic',
+      filter: function(n2k) {
+        return n2k.fields['Heading Magnetic']
+      },
+      source: 'Heading Magnetic'
+    }
+  ]

--- a/raymarine/index.js
+++ b/raymarine/index.js
@@ -1,6 +1,8 @@
 module.exports = {
   65288: require('./65288.js'),
   65345: require('./65345.js'),
+  65359: require('./65359.js'),
   65360: require('./65360.js'),
-  65379: require('./65379.js')
+  65379: require('./65379.js'),
+  126720: require('./126720.js')
 }

--- a/test/126720_seatalk_STNG_pilot_mode.js
+++ b/test/126720_seatalk_STNG_pilot_mode.js
@@ -1,0 +1,49 @@
+var chai = require('chai')
+chai.Should()
+chai.use(require('chai-things'))
+chai.use(require('@signalk/signalk-schema').chaiModule)
+
+describe('126720 Seatalk-STNG-Converter Pilot Mode', function () {
+  it('complet pilot mode sentence converts track', function () {
+    var tree = require('./testMapper').toNested(
+      JSON.parse(
+        '{"timestamp":"2016-10-18T15:52:49.048Z","prio":7,"src":115,"dst":255,"pgn":126720,"description":"Seatalk1: Pilot Mode","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Pilot Mode":"74","Sub Mode":"0","Pilot Mode Data":"0"}}'
+      )
+    )
+    tree.should.have.nested.property('steering.autopilot.state.value', 'route')
+    tree.should.be.validSignalKVesselIgnoringIdentity
+  })
+
+  it('complet pilot mode sentence converts auto', function () {
+    var tree = require('./testMapper').toNested(
+      JSON.parse(
+        '{"timestamp":"2016-09-06T22:56:27.719Z","prio":7,"src":115,"dst":255,"pgn":126720,"description":"Seatalk1: Pilot Mode","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Pilot Mode":"66","Sub Mode":"0","Pilot Mode Data":"0"}}'
+      )
+    )
+    tree.should.have.nested.property('steering.autopilot.state.value', 'auto')
+    tree.should.be.validSignalKVesselIgnoringIdentity
+  })
+
+  it('complet pilot mode sentence converts wind', function () {
+    var tree = require('./testMapper').toNested(
+      JSON.parse(
+        '{"timestamp":"2016-09-06T23:01:38.822Z","prio":7,"src":115,"dst":255,"pgn":126720,"description":"Seatalk1: Pilot Mode","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Pilot Mode":"70","Sub Mode":"0","Pilot Mode Data":"0"}}'
+      )
+    )
+    tree.should.have.nested.property('steering.autopilot.state.value', 'wind')
+    tree.should.be.validSignalKVesselIgnoringIdentity
+  })
+
+  it('complet pilot mode sentence converts standby', function () {
+    var tree = require('./testMapper').toNested(
+      JSON.parse(
+        '{"timestamp":"2016-10-18T15:52:00.751Z","prio":7,"src":115,"dst":255,"pgn":126720,"description":"Seatalk1: Pilot Mode","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Pilot Mode":"0","Sub Mode":"0","Pilot Mode Data":"0"}}'
+      )
+    )
+    tree.should.have.nested.property(
+      'steering.autopilot.state.value',
+      'standby'
+    )
+    tree.should.be.validSignalKVesselIgnoringIdentity
+  })
+})

--- a/test/65359_seatalk_pilot_heading.js
+++ b/test/65359_seatalk_pilot_heading.js
@@ -1,0 +1,31 @@
+var chai = require('chai')
+chai.Should()
+chai.use(require('chai-things'))
+chai.use(require('@signalk/signalk-schema').chaiModule)
+
+describe('65359 Seatalk Pilot Heading', function () {
+  it('complet magnetic sentence converts', function () {
+    var tree = require('./testMapper').toNested(
+      JSON.parse(
+        '{"timestamp":"2016-10-18T15:52:49.041Z","prio":7,"src":115,"dst":255,"pgn":65359,"description":"Seatalk: Pilot Heading","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Heading Magnetic":3.0422}}'
+      )
+    )
+    tree.should.have.nested.property(
+      'navigation.headingMagnetic.value',
+      3.0422
+    )
+    tree.should.be.validSignalKVesselIgnoringIdentity
+  })
+  it('complet true sentence converts', function () {
+    var tree = require('./testMapper').toNested(
+      JSON.parse(
+        '{"timestamp":"2016-10-18T15:52:49.041Z","prio":7,"src":115,"dst":255,"pgn":65359,"description":"Seatalk: Pilot Heading","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Heading True":3.0422}}'
+      )
+    )
+    tree.should.have.nested.property(
+      'navigation.headingTrue.value',
+      3.0422
+    )
+    tree.should.be.validSignalKVesselIgnoringIdentity
+  })
+})

--- a/test/65360_seatalk_pilot_locked_heading.js
+++ b/test/65360_seatalk_pilot_locked_heading.js
@@ -4,7 +4,7 @@ chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('65360 Seatalk Pilot Locked Heading', function () {
-  it('complet wind datum sentence converts', function () {
+  it('complet dual sentence converts', function () {
     var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-10-18T15:52:49.041Z","prio":7,"src":204,"dst":255,"pgn":65360,"description":"Seatalk: Pilot Locked Heading","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Target Heading True":3.0422,"Target Heading Magnetic":3.0122}}'
@@ -20,7 +20,7 @@ describe('65360 Seatalk Pilot Locked Heading', function () {
     )
     tree.should.be.validSignalKVesselIgnoringIdentity
   })
-  it('complet wind datum sentence converts mag', function () {
+  it('complet sentence converts mag', function () {
     var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-10-18T15:52:49.041Z","prio":7,"src":204,"dst":255,"pgn":65360,"description":"Seatalk: Pilot Locked Heading","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Target Heading Magnetic":3.0422}}'
@@ -32,7 +32,7 @@ describe('65360 Seatalk Pilot Locked Heading', function () {
     )
     tree.should.be.validSignalKVesselIgnoringIdentity
   })
-  it('complet wind datum sentence converts true', function () {
+  it('complet sentence converts true', function () {
     var tree = require('./testMapper').toNested(
       JSON.parse(
         '{"timestamp":"2016-10-18T15:52:49.041Z","prio":7,"src":204,"dst":255,"pgn":65360,"description":"Seatalk: Pilot Locked Heading","fields":{"Manufacturer Code":"Raymarine","Industry Code":"Marine Industry","Target Heading True":3.0422}}'


### PR DESCRIPTION
Support for proprietary PGNs of Raymarine SeaTalk-STNG-Converter connected to Raymarine SeaTalk SmartPilot (S1, S2, S3) course computer with ST600X control heads.

I tried to filter 126720 as much as possible with PGN description "Seatalk1: Pilot Mode" and Manufacturer "Raymarine" to limit potential collision with other devices - such as FUSION radio and others.

65359 is the PGN SeaTalk converted Pilot Heading.,