### PR TITLE
chore: add release & changelog actions

### DIFF
--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -1,0 +1,27 @@
+name: 'Release on tag'
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Changelog
+        id: github_release
+        uses: mikepenz/release-changelog-builder-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: ${{steps.github_release.outputs.changelog}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/require_pr_label.yml
+++ b/.github/workflows/require_pr_label.yml
@@ -1,0 +1,13 @@
+name: Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: exactly
+          count: 1
+          labels: "fix, feature, doc, chore, test, ignore, other, dependencies"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,6 @@
   "main": "n2kMapper.js",
   "scripts": {
     "test": "mocha",
-    "create-release": "github-create-release --owner signalk --repository n2k-signalk",
-    "release": "echo 'use npm version to tag, then npm run create-release and GH action will publish the release'",
     "format": "prettier-standard '*.js*' 'pgns/**/*.js' 'test/**/*.js*' 'lowrance/**/*.js*' 'raymarine/**/*.js*'"
   },
   "keywords": [
@@ -30,7 +28,6 @@
     "through": ">=2.2.7 <3"
   },
   "devDependencies": {
-    "@signalk/github-create-release": "^1.0.1",
     "@signalk/server-api": "^1.39.0",
     "@signalk/signalk-schema": "1.3.1",
     "baconjs": "^1.0.1",


### PR DESCRIPTION
Add GH Actions that ensure PRs are tagged for changelog and automation for creating releases from tags.

Remove previous method for creating releases.