### PR TITLE
fix: bad MMSI handling

### DIFF
--- a/n2kMapper.js
+++ b/n2kMapper.js
@@ -190,8 +190,8 @@ var toDelta = function (n2k, state, customPgns = {}) {
         //filter out invalid mmsi
         let last = result.context.lastIndexOf(':')
         if ( last != -1 && result.context.slice(last+1).length < 9 ) {
-          console.log('BAD: ' + result.context)
-          result.updates = []
+          console.error('bad MMSI: ' + result.context)
+          return
         }
       }
 

--- a/test/129038_ais_class_a.js
+++ b/test/129038_ais_class_a.js
@@ -80,7 +80,8 @@ describe('129038 Class A Update', function () {
       "description": "AIS Class A Position Report",
       "timestamp": "2022-05-09T13:38:38.917Z"
     }
-    mapper.toDelta(msg, {}).updates.length.should.equal(0)
+    const deltaType = typeof mapper.toDelta(msg, {})
+    deltaType.should.equal('undefined')
   })
 })
 


### PR DESCRIPTION
n2k-signalk is not expecting values to be zero length https://github.com/SignalK/signalk-server/blob/f800fc9c62b249dc9c7f67252339408b0d8fa304/packages/streams/n2k-signalk.js#L121-L122 so if the MMSI seems to be not ok return undefined, as any of the data in the delta don't make any sense with a questionable MMSI.

This will fix the stacktraces produced by data in the server n2k sample file related to #253 