### PR TITLE
Support Cetrek 2900 wind data (without defined Reference)

### DIFF
--- a/pgns/130306.js
+++ b/pgns/130306.js
@@ -3,7 +3,7 @@ module.exports = [
     source: 'Wind Speed',
     node: 'environment.wind.speedApparent',
     filter: function (n2k) {
-      return n2k.fields['Reference'] === 'Apparent'
+      return n2k.fields['Reference'] === 'Apparent' || n2k.fields['Reference'] === undefined
     }
   },
   {
@@ -23,7 +23,7 @@ module.exports = [
   {
     node: 'environment.wind.angleApparent',
     filter: function (n2k) {
-      return n2k.fields['Reference'] === 'Apparent'
+      return n2k.fields['Reference'] === 'Apparent' || n2k.fields['Reference'] === undefined
     },
     value: function (n2k) {
       var angle = Number(n2k.fields['Wind Angle'])

--- a/test/130306_wind_data.js
+++ b/test/130306_wind_data.js
@@ -98,4 +98,21 @@ describe('130306 Wind Data', function () {
     )
     tree.should.be.validSignalKVesselIgnoringIdentity
   })
+
+  it('Cetrek sentence converts', function () {
+    var tree = require('./testMapper').toNested(
+      JSON.parse(
+        '{"prio":5,"src":75,"dst":255,"pgn":130306,"timestamp":"2022-12-10T15:58:34.529Z","fields":{"Wind Speed":1.54,"Wind Angle":2.3545},"description":"Wind Data"}'
+      )
+    )
+    tree.should.have.nested.property(
+      'environment.wind.speedApparent.value',
+      1.54
+    )
+    tree.should.have.nested.property(
+      'environment.wind.angleApparent.value',
+      2.3545
+    )
+    tree.should.be.validSignalKVesselIgnoringIdentity
+  })
 })


### PR DESCRIPTION
I don't know if this is better handled by a quirks layer in SignalK that lets you work around particular instruments?

But this change is necessary on our yacht to correctly parse Wind data from a Digital  Yacht WND100 feeding NMEA0183 into a Cetrek 2900 which transmits NMEA2000 (marketed as CAN bus, not NMEA2000, but they seem to follow NMEA2000).

Probably not much Cetrek equipment out there these days, I think they stopped making it around 2010. But it's what we've got on board...