### PR TITLE
fix: PGN 127503/127504 -> use new canboatjs2 / canboat4 data, PGN 127501 -> off by one error fixed

### DIFF
--- a/pgns/127501.js
+++ b/pgns/127501.js
@@ -1,7 +1,7 @@
 module.exports = [
   function (n2k) {
     var res = []
-    for (var i = 0; i < 28; i++) {
+    for (var i = 1; i <= 28; i++) {
       const field = 'Indicator' + i
       if (typeof n2k.fields[field] !== 'undefined') {
         const basePath =

--- a/pgns/127503.js
+++ b/pgns/127503.js
@@ -1,66 +1,42 @@
-const { acPhase } = require('../utils.js')
-
 function instance (n2k) {
   return n2k.fields['Instance']
 }
 
-function prefix (n2k) {
-  return `electrical.ac.${instance(n2k)}.${acPhase(n2k)}`
+function acPhase (lineData) {
+  const phaseMap = { 0: 'A', 1: 'B', 2: 'C' }
+  return phaseMap[lineData.Line] ?? 'A'
+}
+
+function prefix (n2k, lineData) {
+  return `electrical.ac.${instance(n2k)}.${acPhase(lineData)}`
 }
 
 module.exports = [
-  {
-    source: 'Acceptability',
-    node: function (n2k) {
-      return `${prefix(n2k)}.acceptability`
+  function (n2k, stage) {
+    const fields = {
+      Acceptability: 'acceptability',
+      Voltage: 'voltage',
+      Current: 'current',
+      Frequency: 'frequency',
+      'Breaker Size': 'breakerSize',
+      'Real Power': 'realPower',
+      'Reactive Power': 'reactivePower',
+      'Power Factor': 'powerFactor'
     }
-  },
-  {
-    source: 'Voltage',
-    node: function (n2k) {
-      return `${prefix(n2k)}.voltage`
-    }
-  },
-  {
-    source: 'Current',
-    node: function (n2k) {
-      return `${prefix(n2k)}.current`
-    }
-  },
-  {
-    source: 'Frequency',
-    node: function (n2k) {
-      return `${prefix(n2k)}.frequency`
-    }
-  },
-  {
-    source: 'Frequency',
-    node: function (n2k) {
-      return `${prefix(n2k)}.frequency`
-    }
-  },
-  {
-    source: 'Breaker Size',
-    node: function (n2k) {
-      return `${prefix(n2k)}.breakerSize`
-    }
-  },
-  {
-    source: 'Real Power',
-    node: function (n2k) {
-      return `${prefix(n2k)}.realPower`
-    }
-  },
-  {
-    source: 'Reactive Power',
-    node: function (n2k) {
-      return `${prefix(n2k)}.reactivePower`
-    }
-  },
-  {
-    source: 'Power Factor',
-    node: function (n2k) {
-      return `${prefix(n2k)}.powerFactor`
-    }
+    return n2k.fields.list
+      ? n2k.fields.list.reduce((updates, lineData) => {
+          const pathPrefix = prefix(n2k, lineData)
+          Object.keys(fields).reduce((fieldUpdates, fieldName) => {
+            if (typeof lineData[fieldName] !== 'undefined') {
+              updates.push({
+                path: `${pathPrefix}.${fields[fieldName]}`,
+                value: lineData[fieldName]
+              })
+            }
+            return updates
+          }, updates)
+          return updates
+        }, [])
+      : []
   }
 ]


### PR DESCRIPTION
Both PGNs (127503 and 127504) have repeatable fields. canboatjs2 and canboat4 messages have
an array in fields called 'list' for these repeated dataset. This wasn't handled correctly by the current version of 127503.js and 127504.js

In my fix the PGNs now export directly a function to generate the deltas. I don't think this is the most
elegant solution, but since the number of lines is variable I couldn't figure out another way.

Unfortunately I have only one AC phase on my boat, it would be good to see real world data using
three phases. I could only simulate it by adding additional lines:

{"canId":435293963,"prio":6,"src":11,"dst":255,"pgn":127503,"timestamp":"2023-11-10T16:16:38.535Z","input":["  can0  19F20F0B   [8]  80 14 00 01 FC C0 58 0F","  can0  19F20F0B   [8]  81 00 88 13 FE FF FF FF","  can0  19F20F0B   [8]  82 FF FF FF FF 00 00 FF"],"fields":{"Instance":0,"Number of Lines":3,"list":[ {"Line":0,"Voltage":227.2,"Current":1.5,"Frequency":50,"Reactive Power":65535}, {"Line":1,"Voltage":227.2,"Current":1.5,"Frequency":50,"Reactive Power":65535}, {"Line":2,"Voltage":227.2,"Current":1.5,"Frequency":50,"Reactive Power":65535} ]},"description":"AC Input Status"}

