### PR TITLE
chore: drop support for Node.js below 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Drop Node.js versions below 18 from support by no longer running automated tests on them. Most code & pgns may still work, but is no longer supported by tests.