### PR TITLE
Fix B&G Waypoint string termination.

### DIFF
--- a/pgns/129285.js
+++ b/pgns/129285.js
@@ -15,7 +15,7 @@ module.exports = [
       var idx = 0
       return n2k.fields.list.map(wp => {
         return {
-          name: wp['WP Name'],
+          name: wp['WP Name'].replace(/\0.*$/g, ''),
           position: {
             value: {
               latitude: wp['WP Latitude'],


### PR DESCRIPTION
B&G string termination issue causes the waypoint pgn to not parse well.