### PR TITLE
fix: remove visual method from 127489 normal state

### DIFF
--- a/pgns/127489.js
+++ b/pgns/127489.js
@@ -234,7 +234,7 @@ function generateMappingsForStatus (field, notifications) {
         } else {
           return {
             state: 'normal',
-            method: ['visual'],
+            method: [],
             message:
               util.format(notif.message, skEngineTitle(n2k)) + ' is Normal'
           }


### PR DESCRIPTION
Normal state should have method array as empty, because it should not result in anything visual or audible.