### PR TITLE
fix: an error is thrown when when a devices src id changes

### DIFF
--- a/n2kMapper.js
+++ b/n2kMapper.js
@@ -127,7 +127,9 @@ N2kMapper.prototype.toDelta = function (n2k) {
           this.state[n2k.src].canName,
           canName
         )
-        this.state[n2k.src] = {}
+        this.state[n2k.src] = {
+          metaPGNsReceived: {}
+        }
         this.requestMetaData(n2k.src, 126996).then(() => {
           return this.requestMetaData(n2k.src, 126998)
         })

--- a/n2kMapper.js
+++ b/n2kMapper.js
@@ -105,11 +105,9 @@ N2kMapper.prototype.toDelta = function (n2k) {
   if (metaPGNs[n2k.pgn]) {
     const meta = metaPGNs[n2k.pgn](n2k)
     if (!this.state[n2k.src]) {
-      this.state[n2k.src] = {}
-    }
-
-    if (!this.state[n2k.src].metaPGNsReceived) {
-      this.state[n2k.src].metaPGNsReceived = {}
+      this.state[n2k.src] = {
+        metaPGNsReceived: {}
+      }
     }
 
     if (n2k.pgn === 60928) {


### PR DESCRIPTION
n2k-signalk: address 0 changed from c0328700227b5a77 c0509b002270da77 TypeError: Cannot set properties of undefined (setting '60928')
    at N2kMapper.toDelta
        (/usr/local/lib/node_modules/signalk-server/node_modules/@signalk/n2k-signalk/n2kMapper.js:140:51)
    at ToSignalK._transform
        (/usr/local/lib/node_modules/signalk-server/node_modules/@signalk/streams/n2k-signalk.js:113:34)
    at Transform._write
        (node:internal/streams/transform:175:8)
    at writeOrBuffer
        (node:internal/streams/writable:392:12)
    at _write
        (node:internal/streams/writable:333:10)
    at Writable.write
        (node:internal/streams/writable:337:10)
    at CanboatJs.ondata
        (node:internal/streams/readable:809:22)
    at CanboatJs.emit
        (node:events:517:28)
    at addChunk
        (node:internal/streams/readable:368:12)
    at readableAddChunk
        (node:internal/streams/readable:341:9)
    at Readable.push
        (node:internal/streams/readable:278:10)
    at CanboatJs._transform
        (/usr/local/lib/node_modules/signalk-server/node_modules/@signalk/streams/canboatjs.js:59:12)
    at Transform._write
        (node:internal/streams/transform:175:8)
    at writeOrBuffer
        (node:internal/streams/writable:392:12)
    at _write
        (node:internal/streams/writable:333:10)
    at Writable.write
        (node:internal/streams/writable:337:10)