### PR TITLE
WIP feature: use canboat "Id" for field names

### DIFF
--- a/aisFromStarboard.js
+++ b/aisFromStarboard.js
@@ -1,6 +1,6 @@
 module.exports = function (n2k) {
-  var fromStarboard = n2k.fields['Position reference from Starboard']
-  var width = n2k.fields['Beam']
+  var fromStarboard = n2k.fields.positionReferenceFromStarboard
+  var width = n2k.fields.beam
   if (fromStarboard > width / 2) {
     return (fromStarboard - width / 2) * -1
   } else {

--- a/fusion/130820.js
+++ b/fusion/130820.js
@@ -4,204 +4,204 @@ var fusionSources = {}
 
 module.exports = [
   {
-    source: 'Name',
+    source: 'name',
     node: 'entertainment.device.fusion1.name',
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Unit Name' }
+    filter: function(n2k) { return n2k.fields.messageId == 'Unit Name' }
   }, {
     node: 'entertainment.device.fusion1.state',
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Power' },
+    filter: function(n2k) { return n2k.fields.messageId == 'Power' },
     value: function(n2k) {
-      return n2k.fields['State'] === 'On' ? 'on' : 'off'
+      return n2k.fields.state === 'On' ? 'on' : 'off'
     }
   }, {
-    source: 'Artist',
+    source: 'artist',
     node: function (n2k) { return 'entertainment.device.fusion1.avsource.source' + currentFusionSource + '.track.artistName' },
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Track Artist' && n2k.fields.Artist != 0 && currentFusionSource != null }
+    filter: function(n2k) { return n2k.fields.messageId == 'Track Artist' && n2k.fields.artist != 0 && currentFusionSource != null }
   }, {
-    source: 'Album',
+    source: 'album',
     node: function(n2k) { return 'entertainment.device.fusion1.avsource.source' + currentFusionSource + '.track.albumName'} ,
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Track Album'  && n2k.fields.Album != 0 && currentFusionSource != null }
+    filter: function(n2k) { return n2k.fields.messageId == 'Track Album'  && n2k.fields.album != 0 && currentFusionSource != null }
   }, {
-    source: 'Track',
+    source: 'track',
     node: function(n2k) { return 'entertainment.device.fusion1.avsource.source' + currentFusionSource + '.track.name'} ,
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Track Title'  && n2k.fields.Track != 0  && currentFusionSource != null  }	
+    filter: function(n2k) { return n2k.fields.messageId == 'Track Title'  && n2k.fields.track != 0  && currentFusionSource != null  }	
   }, {
     //source: 'Progress',
     node: function(n2k) { return 'entertainment.device.fusion1.avsource.source' + currentFusionSource + '.track.elapsedTime'} ,
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Track Progress' && currentFusionSource != null },
+    filter: function(n2k) { return n2k.fields.messageId == 'Track Progress' && currentFusionSource != null },
     value: function(n2k) {
-      return timeToSeconds(n2k.fields['Progress'])
+      return timeToSeconds(n2k.fields.progress)
     }
   }, {
     //source: 'Length',
     node: function(n2k) { return 'entertainment.device.fusion1.avsource.source' + currentFusionSource + '.track.length'} ,
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Track Info' && currentFusionSource != null },
+    filter: function(n2k) { return n2k.fields.messageId == 'Track Info' && currentFusionSource != null },
     value: function(n2k) {
-      return timeToSeconds(n2k.fields['Length'])
+      return timeToSeconds(n2k.fields.length)
     }
   }, {
-    source: 'Artist',
+    source: 'artist',
     node: function(n2k) { return 'entertainment.device.fusion1.avsource.source' + currentFusionSource + '.track.artistName'} ,
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'SiriusXM Artist' && currentFusionSource != null }
+    filter: function(n2k) { return n2k.fields.messageId == 'SiriusXM Artist' && currentFusionSource != null }
   }, {
-    source: 'Title',
+    source: 'title',
     node: function(n2k) { return 'entertainment.device.fusion1.avsource.source' + currentFusionSource + '.track.name'} ,
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'SiriusXM Title' && currentFusionSource != null }
+    filter: function(n2k) { return n2k.fields.messageId == 'SiriusXM Title' && currentFusionSource != null }
   }, {
-    source: 'Channel',
+    source: 'channel',
     node: function(n2k) { return 'entertainment.device.fusion1.avsource.source' + currentFusionSource + '.tuner.stationName'} ,
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'SiriusXM Channel' && currentFusionSource != null  }
+    filter: function(n2k) { return n2k.fields.messageId == 'SiriusXM Channel' && currentFusionSource != null  }
   }, {
-    source: 'Genre',
+    source: 'genre',
     node: function(n2k) { return 'entertainment.device.fusion1.avsource.source' + currentFusionSource + '.track.genre'} ,
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'SiriusXM Genre' && currentFusionSource != null }
+    filter: function(n2k) { return n2k.fields.messageId == 'SiriusXM Genre' && currentFusionSource != null }
   }, {
-    source: 'Track #',
+    source: 'track',
     node: function(n2k) { return 'entertainment.device.fusion1.avsource.source' + currentFusionSource + '.track.number'} ,
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Track Info' && currentFusionSource != null }
+    filter: function(n2k) { return n2k.fields.messageId == 'Track Info' && currentFusionSource != null }
   }, {
-    source: 'Track Count',
+    source: 'trackCount',
     node: function(n2k) { return 'entertainment.device.fusion1.avsource.source' + currentFusionSource + '.track.totalTracks'} ,
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Track Info' && currentFusionSource != null }
+    filter: function(n2k) { return n2k.fields.messageId == 'Track Info' && currentFusionSource != null }
   }, {
     node: 'entertainment.device.fusion1.output.zone1.volume.master',
-    source: 'Zone 1',
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Volume' }
+    source: 'zone1',
+    filter: function(n2k) { return n2k.fields.messageId == 'Volume' }
   }, {
     node: 'entertainment.device.fusion1.output.zone2.volume.master',
-    source: 'Zone 2',
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Volume' }
+    source: 'zone2',
+    filter: function(n2k) { return n2k.fields.messageId == 'Volume' }
   }, {
     node: 'entertainment.device.fusion1.output.zone3.volume.master',
-    source: 'Zone 3',
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Volume' }
+    source: 'zone3',
+    filter: function(n2k) { return n2k.fields.messageId == 'Volume' }
   }, {
     node: 'entertainment.device.fusion1.output.zone4.volume.master',
-    source: 'Zone 4',
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Volume' }
+    source: 'zone4',
+    filter: function(n2k) { return n2k.fields.messageId == 'Volume' }
   }, {
-    node: function (n2k) { return 'entertainment.device.fusion1.output.zone' + (Number(n2k.fields.Number)+1) + '.name' },
+    node: function (n2k) { return 'entertainment.device.fusion1.output.zone' + (Number(n2k.fields.number)+1) + '.name' },
 
-    source: 'Name',
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Zone Name' }
+    source: 'name',
+    filter: function(n2k) { return n2k.fields.messageId == 'Zone Name' }
 
 
    }, {
     node: 'entertainment.device.fusion1.output.zone1.source',
      value: function(n2k) {
-       currentFusionSource = n2k.fields['Current Source ID']
-       return 'entertainment.device.fusion1.avsource.source' + n2k.fields['Current Source ID']
+       currentFusionSource = n2k.fields.currentSourceId
+       return 'entertainment.device.fusion1.avsource.source' + n2k.fields.currentSourceId
      },
-     filter: function(n2k) { return n2k.fields['Message ID'] == 'Source' }
+     filter: function(n2k) { return n2k.fields.messageId == 'Source' }
    }, {
     node: 'entertainment.device.fusion1.output.zone2.source',
      value: function(n2k) {
-       return 'entertainment.device.fusion1.avsource.source' + n2k.fields['Current Source ID']
+       return 'entertainment.device.fusion1.avsource.source' + n2k.fields.currentSourceId
      },
-     filter: function(n2k) { return n2k.fields['Message ID'] == 'Source' }
+     filter: function(n2k) { return n2k.fields.messageId == 'Source' }
    }, {
      node: 'entertainment.device.fusion1.output.zone3.source',
      value: function(n2k) {
-       return 'entertainment.device.fusion1.avsource.source' + n2k.fields['Current Source ID']
+       return 'entertainment.device.fusion1.avsource.source' + n2k.fields.currentSourceId
      },
-     filter: function(n2k) { return n2k.fields['Message ID'] == 'Source' }
+     filter: function(n2k) { return n2k.fields.messageId == 'Source' }
    }, {
      node: 'entertainment.device.fusion1.output.zone4.source',
      value: function(n2k) {
-       return 'entertainment.device.fusion1.avsource.source' + n2k.fields['Current Source ID']
+       return 'entertainment.device.fusion1.avsource.source' + n2k.fields.currentSourceId
      },
-     filter: function(n2k) { return n2k.fields['Message ID'] == 'Source' }
+     filter: function(n2k) { return n2k.fields.messageId == 'Source' }
   }, {
-    node: function (n2k) { return 'entertainment.device.fusion1.avsource.source' + n2k.fields['Source ID'] + '.name' },
+    node: function (n2k) { return 'entertainment.device.fusion1.avsource.source' + n2k.fields.sourceId + '.name' },
     value: function(n2k) {
-      fusionSources[n2k.fields['Source ID']] = n2k.fields.Source
-      return n2k.fields.Source
+      fusionSources[n2k.fields.sourceId] = n2k.fields.source
+      return n2k.fields.source
     },
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Source' }
+    filter: function(n2k) { return n2k.fields.messageId == 'Source' }
     
   }, {
-    source: 'AM/FM',
+    source: 'amFm',
     node: function(n2k) { return 'entertainment.device.fusion1.avsource.source' + currentFusionSource + '.tuner.mode'} ,
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'AM/FM Station' && currentFusionSource != null}
+    filter: function(n2k) { return n2k.fields.messageId == 'AM/FM Station' && currentFusionSource != null}
   }, {
-    source: 'Frequency',
+    source: 'frequency',
     node: function(n2k) { return 'entertainment.device.fusion1.avsource.source' + currentFusionSource + '.tuner.frequency'} ,
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'AM/FM Station' && currentFusionSource != null }
+    filter: function(n2k) { return n2k.fields.messageId == 'AM/FM Station' && currentFusionSource != null }
   }, {
     node: function(n2k) { return 'entertainment.device.fusion1.avsource.source' + currentFusionSource + '.playbackState'} ,
     value: function(n2k) {
-      var val = n2k.fields['Transport']
+      var val = n2k.fields.transport
       return val == 'Paused' || val == 'Stop' ? 'Paused' : 'Playing'
     },
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Track Info' }
+    filter: function(n2k) { return n2k.fields.messageId == 'Track Info' }
   }, {
     node: 'entertainment.device.fusion1.output.zone1.isMuted',
     value: function(n2k) {
-      var val = n2k.fields['Mute']
+      var val = n2k.fields.mute
       return val == 'Mute On' ? true : false
     },
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Mute' }
+    filter: function(n2k) { return n2k.fields.messageId == 'Mute' }
   }, {
     node: 'entertainment.device.fusion1.output.zone2.isMuted',
     value: function(n2k) {
-      var val = n2k.fields['Mute']
+      var val = n2k.fields.mute
       return val == 'Mute On' ? true : false
     },
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Mute' }
+    filter: function(n2k) { return n2k.fields.messageId == 'Mute' }
   }, {
     node: 'entertainment.device.fusion1.output.zone3.isMuted',
     value: function(n2k) {
-      var val = n2k.fields['Mute']
+      var val = n2k.fields.mute
       return val == 'Mute On' ? true : false
     },
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Mute' }
+    filter: function(n2k) { return n2k.fields.messageId == 'Mute' }
   }, {
     node: 'entertainment.device.fusion1.output.zone4.isMuted',
     value: function(n2k) {
-      var val = n2k.fields['Mute']
+      var val = n2k.fields.mute
       return val == 'Mute On' ? true : false
     },
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Mute' }
+    filter: function(n2k) { return n2k.fields.messageId == 'Mute' }
     
   }, {
     node: 'entertainment.device.fusion1.output.zone1.equalizer',
     value: function(n2k) {
       return {
-	bass: Number(n2k.fields.Bass),
-	mid: Number(n2k.fields.Mid),
-	treble: Number(n2k.fields.Treble)
+	bass: Number(n2k.fields.bass),
+	mid: Number(n2k.fields.mid),
+	treble: Number(n2k.fields.treble)
       }
     },
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Tone' }
+    filter: function(n2k) { return n2k.fields.messageId == 'Tone' }
   }, {
     node: 'entertainment.device.fusion1.output.zone2.equalizer',
     value: function(n2k) {
       return {
-	bass: Number(n2k.fields.Bass),
-	mid: Number(n2k.fields.Mid),
-	treble: Number(n2k.fields.Treble)
+	bass: Number(n2k.fields.bass),
+	mid: Number(n2k.fields.mid),
+	treble: Number(n2k.fields.treble)
       }
     },
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Tone' }
+    filter: function(n2k) { return n2k.fields.messageId == 'Tone' }
   }, {
     node: 'entertainment.device.fusion1.output.zone3.equalizer',
     value: function(n2k) {
       return {
-	bass: Number(n2k.fields.Bass),
-	mid: Number(n2k.fields.Mid),
-	treble: Number(n2k.fields.Treble)
+	bass: Number(n2k.fields.bass),
+	mid: Number(n2k.fields.mid),
+	treble: Number(n2k.fields.treble)
       }
     },
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Tone' }
+    filter: function(n2k) { return n2k.fields.messageId == 'Tone' }
   }, {
     node: 'entertainment.device.fusion1.output.zone4.equalizer',
     value: function(n2k) {
       return {
-	bass: Number(n2k.fields.Bass),
-	mid: Number(n2k.fields.Mid),
-	treble: Number(n2k.fields.Treble)
+	bass: Number(n2k.fields.bass),
+	mid: Number(n2k.fields.mid),
+	treble: Number(n2k.fields.treble)
       }
     },
-    filter: function(n2k) { return n2k.fields['Message ID'] == 'Tone' }
+    filter: function(n2k) { return n2k.fields.messageId == 'Tone' }
   }
 ]

--- a/lowrance/65285.js
+++ b/lowrance/65285.js
@@ -2,10 +2,10 @@ const temperatureMappings = require('../temperatureMappings')
 
 module.exports = [
   {
-    source: 'Actual Temperature',
+    source: 'actualTemperature',
     node: function (n2k) {
       var temperatureMapping =
-        temperatureMappings[n2k.fields['Temperature Source']]
+        temperatureMappings[n2k.fields.temperatureSource]
 
       if (temperatureMappings) {
         if (temperatureMapping.pathWithIndex) {
@@ -16,10 +16,10 @@ module.exports = [
       }
     },
     instance: function (n2k) {
-      return n2k.fields['Temperature Instance'] + ''
+      return n2k.fields.temperatureInstance + ''
     },
     filter: function (n2k) {
-      return n2k.fields['Actual Temperature']
+      return n2k.fields.actualTemperature
     }
   }
 ]

--- a/maretron/power.js
+++ b/maretron/power.js
@@ -7,7 +7,7 @@ module.exports = function(type, phase) {
   
   return [
     {
-      source: 'Real Power',
+      source: 'realPower',
       node: function (n2k, state) {
         return `${prefix(n2k, state)}.realPower`
       },
@@ -21,10 +21,10 @@ module.exports = function(type, phase) {
       },
       value: (n2k, state) => {
         const pf = get(state, `maretron.${prefix(n2k, state)}.powerFactor`)
-        return n2k.fields['Apparent Power'] * pf
+        return n2k.fields.apparentPower * pf
       },
       filter: (n2k, state) => {
-        return n2k.fields['Apparent Power'] != null &&
+        return n2k.fields.apparentPower != null &&
           get(state, `maretron.${prefix(n2k, state)}.powerFactor`) != null &&
           state.deviceInstance != null
       }

--- a/maretron/quantities.js
+++ b/maretron/quantities.js
@@ -6,7 +6,7 @@ module.exports = (type, phase) => {
 
   return [
     {
-      source: 'Line-Line AC RMS Voltage',
+      source: 'lineLineAcRmsVoltage',
       node: function (n2k, state) {
         return `${prefix(n2k, state)}.lineLineVoltage`
       },
@@ -15,7 +15,7 @@ module.exports = (type, phase) => {
       }
     },
     {
-      source: 'Line-Neutral AC RMS Voltage',
+      source: 'lineNeutralAcRmsVoltage',
       node: function (n2k, state) {
         return `${prefix(n2k, state)}.lineNeutralVoltage`
       },
@@ -24,7 +24,7 @@ module.exports = (type, phase) => {
       }
     },
     {
-      source: 'AC Frequency',
+      source: 'acFrequency',
       node: function (n2k, state) {
         return `${prefix(n2k, state)}.frequency`
       },
@@ -33,7 +33,7 @@ module.exports = (type, phase) => {
       }
     },
     {
-      source: 'AC RMS Current',
+      source: 'acRmsCurrent',
       node: function (n2k, state) {
         return `${prefix(n2k, state)}.current`
       },

--- a/maretron/reactivePower.js
+++ b/maretron/reactivePower.js
@@ -8,7 +8,7 @@ module.exports = (type, phase) => {
   
   return [
     { 
-      source: 'Reactive Power',
+      source: 'reactivePower',
       node: function (n2k, state) {
         return `${prefix(n2k, state)}.reactivePower`
       },
@@ -21,12 +21,12 @@ module.exports = (type, phase) => {
         return `${prefix(n2k, state)}.powerFactor`
       },
       value: (n2k, state) => {
-      const val = n2k.fields['Power Factor']
+      const val = n2k.fields.powerFactor
         set(state, `maretron.${prefix(n2k, state)}.powerFactor`, val)
         return val / 32768
       },
       filter: (n2k, state) => {
-        return n2k.fields['Power Factor'] != null &&
+        return n2k.fields.powerFactor != null &&
           state.deviceInstance != null
       }
     },
@@ -35,10 +35,10 @@ module.exports = (type, phase) => {
         return `${prefix(n2k, state)}.powerFactorLagging`
       },
       value: (n2k) => {
-        return n2k.fields['Power Factor Lagging'].toLowerCase()
+        return n2k.fields.powerFactorLagging.toLowerCase()
       },
       filter: (n2k, state) => {
-        return n2k.fields['Power Factor Lagging'] != null &&
+        return n2k.fields.powerFactorLagging != null &&
           state.deviceInstance != null
       }
     },

--- a/maretron/totalEnergy.js
+++ b/maretron/totalEnergy.js
@@ -9,10 +9,10 @@ module.exports = (type) => {
         return `${prefix(n2k, state)}.energyExport`
       },
       value: (n2k) => {
-        return n2k.fields['Total Energy Export']
+        return n2k.fields.totalEnergyExport
       },
       filter: (n2k, state) => {
-        return n2k.fields['Total Energy Export'] != null &&
+        return n2k.fields.totalEnergyExport != null &&
           state.deviceInstance != null
       }
     },
@@ -21,10 +21,10 @@ module.exports = (type) => {
         return `${prefix(n2k, state)}.energyImport`
       },
       value: (n2k) => {
-        return n2k.fields['Total Energy Import']
+        return n2k.fields.totalEnergyImport
       },
       filter: (n2k, state) => {
-        return n2k.fields['Total Energy Import'] != null &&
+        return n2k.fields.totalEnergyImport != null &&
           state.deviceInstance != null
       }
     }

--- a/mmsi-context.js
+++ b/mmsi-context.js
@@ -1,11 +1,11 @@
 module.exports.getMmsiContext = function (n2k) {
-  return typeof n2k.fields['User ID'] !== 'undefined'
-    ? 'vessels.urn:mrn:imo:mmsi:' + n2k.fields['User ID']
+  return typeof n2k.fields.userId !== 'undefined'
+    ? 'vessels.urn:mrn:imo:mmsi:' + n2k.fields.userId
     : undefined
 }
 
 function padUserID (n2k) {
-  let id = n2k.fields['User ID']
+  let id = n2k.fields.userId
   if (typeof id !== 'undefined') {
     id = id.toString()
     return id != '0' ? id.padStart(9, '0') : id

--- a/n2kMapper.js
+++ b/n2kMapper.js
@@ -190,6 +190,7 @@ var toDelta = function (n2k, state, customPgns = {}) {
         }
       ]
     }
+
     if (src_state && src_state.canName) {
       result.updates[0].source.canName = src_state.canName
     }
@@ -218,6 +219,7 @@ var toDelta = function (n2k, state, customPgns = {}) {
         result.updates[0].source.instance = theMappings[0].instance(n2k)
       }
     }
+    
     return result
   } catch (ex) {
     console.error(ex)
@@ -310,6 +312,7 @@ var toValuesArray = function (theMappings, n2k, state) {
           }
         } catch (ex) {
           process.stderr.write(ex + ' ' + JSON.stringify(n2k))
+          console.error(ex)
         }
         return updates
       }, [])
@@ -359,36 +362,36 @@ function addAsNested (pathValue, source, timestamp, result) {
 const metaPGNs = {
   60928: n2k => {
     return {
-      uniqueId: n2k.fields['Unique Number'],
-      manufacturerName: n2k.fields['Manufacturer Code'],
-      deviceFunction: n2k.fields['Device Function'],
-      deviceClass: n2k.fields['Device Class'],
-      deviceInstanceLower: n2k.fields['Device Instance Lower'],
-      deviceInstanceUpper: n2k.fields['Device Instance Upper'],
-      systemInstance: n2k.fields['System Instance'],
+      uniqueId: n2k.fields.uniqueNumber,
+      manufacturerName: n2k.fields.manufacturerCode,
+      deviceFunction: n2k.fields.deviceFunction,
+      deviceClass: n2k.fields.deviceClass,
+      deviceInstanceLower: n2k.fields.deviceInstanceLower,
+      deviceInstanceUpper: n2k.fields.deviceInstanceUpper,
+      systemInstance: n2k.fields.systemInstance,
       deviceInstance:
-        (n2k.fields['Device Instance Upper'] << 3) |
-        n2k.fields['Device Instance Lower']
+        (n2k.fields.deviceInstanceUpper << 3) |
+        n2k.fields.deviceInstanceLower
     }
   },
   126998: n2k => {
     return {
-      installationNote1: n2k.fields['Installation Description #1'],
-      installationNote2: n2k.fields['Installation Description #2'],
-      installationNote3: n2k.fields['Installation Description #3'],
-      manufacturerInfo: n2k.fields['Manufacturer Information']
+      installationNote1: n2k.fields.installationDescription1,
+      installationNote2: n2k.fields.installationDescription2,
+      installationNote3: n2k.fields.installationDescription3,
+      manufacturerInfo: n2k.fields.manufacturerInformation
     }
   },
   126996: n2k => {
     return {
-      productName: n2k.fields['Model ID'],
-      hardwareVersion: n2k.fields['Model Version'],
-      softwareVersion: n2k.fields['Software Version Code'],
-      productID: n2k.fields['Product Code'],
-      serialNumber: n2k.fields['Model Serial Code'],
-      nmea2000Version: n2k.fields['NMEA 2000 Version'],
-      certificationLevel: n2k.fields['Certification Level'],
-      loadEquivalency: n2k.fields['Load Equivalency']
+      productName: n2k.fields.modelId,
+      hardwareVersion: n2k.fields.modelVersion,
+      softwareVersion: n2k.fields.softwareVersionCode,
+      productID: n2k.fields.productCode,
+      serialNumber: n2k.fields.modelSerialCode,
+      nmea2000Version: n2k.fields.nmea2000Version,
+      certificationLevel: n2k.fields.certificationLevel,
+      loadEquivalency: n2k.fields.loadEquivalency
     }
   }
 }

--- a/pgns/126983.js
+++ b/pgns/126983.js
@@ -23,9 +23,9 @@ const alertTypes = [
 module.exports = [
   {
     node: function (n2k, state) {
-      var alertType = n2k.fields['Alert Type'].replace(/ /g, '').toLowerCase()
+      var alertType = n2k.fields.alertType.replace(/ /g, '').toLowerCase()
 
-      var alertCategory = n2k.fields['Alert Category'].toLowerCase()
+      var alertCategory = n2k.fields.alertCategory.toLowerCase()
 
       var path =
         'notifications.nmea.' +
@@ -33,9 +33,9 @@ module.exports = [
         '.' +
         alertCategory +
         '.' +
-        n2k.fields['Alert System'] +
+        n2k.fields.alertSystem +
         '.' +
-        n2k.fields['Alert ID']
+        n2k.fields.alertId
       debug('126983 path: ' + path)
 
       return path
@@ -44,55 +44,55 @@ module.exports = [
       debug('126983 value')
 
       var skstate = alertTypes.filter(
-        alertType => alertType.nmea === n2k.fields['Alert Type']
+        alertType => alertType.nmea === n2k.fields.alertType
       )
       debug('126983 skstate: ' + skstate[0].sk)
 
-      var alertId = n2k.fields['Alert ID']
+      var alertId = n2k.fields.alertId
 
       var value = {
         state: skstate[0].sk,
         method: ['visual', 'sound'],
         message: state.alerts[alertId].textDescription,
-        alertType: n2k.fields['Alert Type'],
-        alertCategory: n2k.fields['Alert Category'],
-        alertSystem: n2k.fields['Alert System'],
-        alertId: n2k.fields['Alert ID'],
-        dataSourceNetworkIDNAME: n2k.fields['Data Source Network ID NAME'],
-        dataSourceInstance: n2k.fields['Data Source Instance'],
-        'dataSourceIndex-Source': n2k.fields['Data Source Index-Source'],
-        occurrence: n2k.fields['Alert Occurrence Number'],
-        temporarySilenceStatus: n2k.fields['Temporary Silence Status'],
-        acknowledgeStatus: n2k.fields['Acknowledge Status'],
-        escalationStatus: n2k.fields['Escalation Status'],
-        temporarySilenceSupport: n2k.fields['Temporary Silence Support'],
-        acknowledgeSupport: n2k.fields['Acknowledge Support'],
-        escalationSupport: n2k.fields['Escalation Support'],
+        alertType: n2k.fields.alertType,
+        alertCategory: n2k.fields.alertCategory,
+        alertSystem: n2k.fields.alertSystem,
+        alertId: n2k.fields.alertId,
+        dataSourceNetworkIDNAME: n2k.fields.dataSourceNetworkIdName,
+        dataSourceInstance: n2k.fields.dataSourceInstance,
+        'dataSourceIndex-Source': n2k.fields.dataSourceIndexSource,
+        occurrence: n2k.fields.alertOccurrenceNumber,
+        temporarySilenceStatus: n2k.fields.temporarySilenceStatus,
+        acknowledgeStatus: n2k.fields.acknowledgeStatus,
+        escalationStatus: n2k.fields.escalationStatus,
+        temporarySilenceSupport: n2k.fields.temporarySilenceSupport,
+        acknowledgeSupport: n2k.fields.acknowledgeSupport,
+        escalationSupport: n2k.fields.escalationSupport,
         acknowledgeSourceNetworkIDNAME:
-          n2k.fields['Acknowledge Source Network ID NAME'],
-        triggerCondition: n2k.fields['Trigger Condition'],
-        thresholdStatus: n2k.fields['Threshold Status'],
-        alertPriority: n2k.fields['Alert Priority'],
-        alertState: n2k.fields['Alert State']
+          n2k.fields.acknowledgeSourceNetworkIdName,
+        triggerCondition: n2k.fields.triggerCondition,
+        thresholdStatus: n2k.fields.thresholdStatus,
+        alertPriority: n2k.fields.alertPriority,
+        alertState: n2k.fields.alertState
       }
 
       //if the alert is silenced or acknowledged then dont alert in SK
       if (
-        n2k.fields['Temporary Silence Status'] == 'Yes' ||
-        n2k.fields['Acknowledge Status'] == 'Yes'
+        n2k.fields.temporarySilenceStatus == 'Yes' ||
+        n2k.fields.acknowledgeStatus == 'Yes'
       ) {
         value.method = []
       }
-      debug('126983 value: ' + JSON.stringify(value))
+      debug('126983 value: ' + JSON.stringify(value, null, 2))
 
       return value
     },
     filter: function (n2k, state) {
       return (
-        n2k.fields['Alert Type'] &&
+        n2k.fields.alertType &&
         typeof state === 'object' &&
         state.alerts &&
-        state.alerts[n2k.fields['Alert ID']]
+        state.alerts[n2k.fields.alertId]
       )
     }
   }

--- a/pgns/126985.js
+++ b/pgns/126985.js
@@ -5,12 +5,12 @@ module.exports = [
   {
     filter: function (n2k, state) {
       if (typeof state !== 'undefined') {
-        var alertId = n2k.fields['Alert ID']
+        var alertId = n2k.fields.alertId
         var text = {
-          languageId: n2k.fields['Language ID'],
-          textDescription: n2k.fields['Alert Text Description'],
+          languageId: n2k.fields.languageId,
+          textDescription: n2k.fields.alertTextDescription,
           locationTextDescription:
-            n2k.fields['Alert Location Text Description'] || ''
+            n2k.fields.alertLocationTextDescription || ''
         }
         //store the alert text in state for use with PGN 126983
         if (!state.alerts) {
@@ -22,6 +22,6 @@ module.exports = [
       }
       return false
     },
-    source: 'Alert Text'
+    source: 'alertText'
   }
 ]

--- a/pgns/126992.js
+++ b/pgns/126992.js
@@ -1,12 +1,12 @@
 module.exports = [
   {
     value: function (n2k) {
-      return n2k.fields.Date.replace(/\./g, '-') + 'T' + n2k.fields.Time + 'Z'
+      return n2k.fields.date.replace(/\./g, '-') + 'T' + n2k.fields.time + 'Z'
     },
     filter: function (n2k) {
       return (
-        typeof n2k.fields['Date'] !== 'undefined' &&
-        typeof n2k.fields['Time'] !== 'undefined'
+        typeof n2k.fields.date !== 'undefined' &&
+        typeof n2k.fields.time !== 'undefined'
       )
     },
     node: 'navigation.datetime'

--- a/pgns/127237.js
+++ b/pgns/127237.js
@@ -1,13 +1,13 @@
 module.exports = [
   {
-    source: 'Heading-To-Steer (Course)',
+    source: 'headingToSteerCourse',
     node: function (n2k) {
       const reference =
-        n2k.fields['Heading Reference'] === 'Magnetic' ? 'Magnetic' : 'True'
+        n2k.fields.headingReference === 'Magnetic' ? 'Magnetic' : 'True'
       return `steering.autopilot.target.heading${reference}`
     },
     filter: function (n2k) {
-      return typeof n2k.fields['Heading-To-Steer (Course)'] !== 'undefined'
+      return typeof n2k.fields.headingToSteerCourse !== 'undefined'
     }
   }
 ]

--- a/pgns/127245.js
+++ b/pgns/127245.js
@@ -1,9 +1,9 @@
 module.exports = [
   {
-    source: 'Position',
+    source: 'position',
     node: 'steering.rudderAngle',
     filter: function (n2k) {
-      return typeof n2k.fields['Position'] !== 'undefined'
+      return typeof n2k.fields.position !== 'undefined'
     }
   }
 ]

--- a/pgns/127250.js
+++ b/pgns/127250.js
@@ -1,36 +1,36 @@
 module.exports = [
   {
-    source: 'Heading',
+    source: 'heading',
     node: 'navigation.headingMagnetic',
     filter: function (n2k) {
       return (
-        n2k.fields['Reference'] === 'Magnetic' &&
-        typeof n2k.fields['Heading'] !== 'undefined'
+        n2k.fields.reference === 'Magnetic' &&
+        typeof n2k.fields.heading !== 'undefined'
       )
     }
   },
   {
-    source: 'Heading',
+    source: 'heading',
     node: 'navigation.headingTrue',
     filter: function (n2k) {
       return (
-        n2k.fields['Reference'] === 'True' &&
-        typeof n2k.fields['Heading'] !== 'undefined'
+        n2k.fields.reference === 'True' &&
+        typeof n2k.fields.heading !== 'undefined'
       )
     }
   },
   {
-    source: 'Variation',
+    source: 'variation',
     node: 'navigation.magneticVariation',
     filter: function (n2k) {
-      return typeof n2k.fields['Variation'] !== 'undefined'
+      return typeof n2k.fields.variation !== 'undefined'
     }
   },
   {
-    source: 'Deviation',
+    source: 'deviation',
     node: 'navigation.magneticDeviation',
     filter: function (n2k) {
-      return typeof n2k.fields['Deviation'] !== 'undefined'
+      return typeof n2k.fields.deviation !== 'undefined'
     }
   }
 ]

--- a/pgns/127251.js
+++ b/pgns/127251.js
@@ -1,6 +1,6 @@
 module.exports = [
   {
-    source: 'Rate',
+    source: 'rate',
     node: 'navigation.rateOfTurn'
   }
 ]

--- a/pgns/127257.js
+++ b/pgns/127257.js
@@ -2,9 +2,9 @@ module.exports = [
   {
     value: function (n2k) {
       return {
-        yaw: Number(n2k.fields.Yaw),
-        pitch: Number(n2k.fields.Pitch),
-        roll: Number(n2k.fields.Roll)
+        yaw: Number(n2k.fields.yaw),
+        pitch: Number(n2k.fields.pitch),
+        roll: Number(n2k.fields.roll)
       }
     },
     node: 'navigation.attitude'

--- a/pgns/127258.js
+++ b/pgns/127258.js
@@ -1,6 +1,6 @@
 module.exports = [
   {
-    source: 'Variation',
+    source: 'variation',
     node: 'navigation.magneticVariation'
   }
 ]

--- a/pgns/127488.js
+++ b/pgns/127488.js
@@ -6,7 +6,7 @@ module.exports = [
       return 'propulsion.' + skEngineId(n2k) + '.revolutions'
     },
     value: function (n2k) {
-      var rpm = Number(chooseField(n2k, 'Engine Speed', 'Speed'))
+      var rpm = Number(n2k.fields.speed)
       return rpm / 60.0
     }
   },
@@ -15,7 +15,7 @@ module.exports = [
       return 'propulsion.' + skEngineId(n2k) + '.drive.trimState'
     },
     value: function (n2k) {
-      var trimPos = Number(n2k.fields['Tilt/Trim'])
+      var trimPos = Number(n2k.fields.tiltTrim)
 
       if (trimPos > 0) {
         trimPos = trimPos / 100
@@ -24,13 +24,13 @@ module.exports = [
       return trimPos
     },
     filter: function (n2k) {
-      return typeof n2k.fields['Tilt/Trim'] !== 'undefined'
+      return typeof n2k.fields.tiltTrim !== 'undefined'
     }
   },
   {
     node: function (n2k) {
       return 'propulsion.' + skEngineId(n2k) + '.boostPressure'
     },
-    source: 'Boost Pressure'
+    source: 'boostPressure'
   }
 ]

--- a/pgns/127489.js
+++ b/pgns/127489.js
@@ -8,13 +8,13 @@ const {
 
 module.exports = [
   {
-    source: 'Temperature',
+    source: 'temperature',
     node: function (n2k) {
       return 'propulsion.' + skEngineId(n2k) + '.temperature'
     }
   },
   {
-    source: 'Alternator Potential',
+    source: 'alternatorPotential',
     node: function (n2k) {
       return 'propulsion.' + skEngineId(n2k) + '.alternatorVoltage'
     }
@@ -24,7 +24,7 @@ module.exports = [
       return 'propulsion.' + skEngineId(n2k) + '.fuel.rate'
     },
     value: function (n2k) {
-      var lph = Number(n2k.fields['Fuel Rate'])
+      var lph = Number(n2k.fields.fuelRate)
       return isNaN(lph) ? null : lph / 3600000
     }
   },
@@ -33,7 +33,7 @@ module.exports = [
       return 'propulsion.' + skEngineId(n2k) + '.oilPressure'
     },
     value: function (n2k) {
-      var kpa = Number(n2k.fields['Oil pressure'])
+      var kpa = Number(n2k.fields.oilPressure)
       return isNaN(kpa) ? null : kpa
     }
   },
@@ -42,11 +42,11 @@ module.exports = [
       return 'propulsion.' + skEngineId(n2k) + '.runTime'
     },
     value: function (n2k) {
-      return timeToSeconds(n2k.fields['Total Engine hours'])
+      return timeToSeconds(n2k.fields.totalEngineHours)
     }
   },
   {
-    source: 'Oil temperature',
+    source: 'oilTemperature',
     node: function (n2k) {
       return 'propulsion.' + skEngineId(n2k) + '.oilTemperature'
     }
@@ -56,7 +56,7 @@ module.exports = [
       return 'propulsion.' + skEngineId(n2k) + '.coolantPressure'
     },
     value: function (n2k) {
-      var kpa = Number(n2k.fields['Coolant Pressure'])
+      var kpa = Number(n2k.fields.coolantPressure)
       return isNaN(kpa) ? null : kpa * 1000.0
     }
   },
@@ -65,7 +65,7 @@ module.exports = [
       return 'propulsion.' + skEngineId(n2k) + '.engineLoad'
     },
     value: function (n2k) {
-      var percent = Number(n2k.fields['Engine Load'])
+      var percent = Number(n2k.fields.engineLoad)
       return isNaN(percent) ? null : percent / 100.0
     }
   },
@@ -74,7 +74,7 @@ module.exports = [
       return 'propulsion.' + skEngineId(n2k) + '.engineTorque'
     },
     value: function (n2k) {
-      var percent = Number(n2k.fields['Engine Torque'])
+      var percent = Number(n2k.fields.engineTorque)
       return isNaN(percent) ? null : percent / 100.0
     }
   },
@@ -83,7 +83,7 @@ module.exports = [
       return 'propulsion.' + skEngineId(n2k) + '.fuel.pressure'
     },
     value: function (n2k) {
-      var kpa = Number(n2k.fields['Fuel Pressure'])
+      var kpa = Number(n2k.fields.fuelPressure)
       return isNaN(kpa) ? null : kpa * 1000.0
     }
   }
@@ -245,5 +245,5 @@ function generateMappingsForStatus (field, notifications) {
   })
 }
 
-generateMappingsForStatus('Discrete Status 1', status1Notifications)
-generateMappingsForStatus('Discrete Status 2', status2Notifications)
+generateMappingsForStatus('discreteStatus1', status1Notifications)
+generateMappingsForStatus('discreteStatus2', status2Notifications)

--- a/pgns/127493.js
+++ b/pgns/127493.js
@@ -3,13 +3,13 @@ const { chooseField, skEngineId, skEngineTitle } = require('../utils.js')
 
 module.exports = [
   {
-    source: 'Oil temperature',
+    source: 'oilTemperature',
     node: function (n2k) {
       return 'propulsion.' + skEngineId(n2k) + '.transmission.oilTemperature'
     }
   },
   {
-    source: 'Transmission Gear',
+    source: 'transmissionGear',
     node: function (n2k) {
       return 'propulsion.' + skEngineId(n2k) + '.transmission.gear'
     }
@@ -19,7 +19,7 @@ module.exports = [
       return 'propulsion.' + skEngineId(n2k) + '.transmission.oilPressure'
     },
     value: function (n2k) {
-      var kpa = Number(n2k.fields['Oil pressure'])
+      var kpa = Number(n2k.fields.oilPressure)
       return isNaN(kpa) ? null : kpa
     }
   }
@@ -92,4 +92,4 @@ function generateMappingsForStatus (field, notifications) {
   })
 }
 
-generateMappingsForStatus('Discrete Status 1', status1Notifications)
+generateMappingsForStatus('discreteStatus1', status1Notifications)

--- a/pgns/127497.js
+++ b/pgns/127497.js
@@ -6,10 +6,10 @@ module.exports = [
       return 'propulsion.' + skEngineId(n2k) + '.trip.fuelUsed'
     },
     value: function (n2k) {
-      return n2k.fields['Trip Fuel Used'] / 1000
+      return n2k.fields.tripFuelUsed / 1000
     },
     filter: function (n2k) {
-      return typeof n2k.fields['Trip Fuel Used'] !== 'undefined'
+      return typeof n2k.fields.tripFuelUsed !== 'undefined'
     }
   },
   {
@@ -17,10 +17,10 @@ module.exports = [
       return 'propulsion.' + skEngineId(n2k) + '.trip.fuelRate.average'
     },
     value: function (n2k) {
-      return n2k.fields['Fuel Rate, Average'] / 1000
+      return n2k.fields.fuelRateAverage / 1000
     },
     filter: function (n2k) {
-      return typeof n2k.fields['Fuel Rate, Average'] !== 'undefined'
+      return typeof n2k.fields.fuelRateAverage !== 'undefined'
     }
   },
   {
@@ -28,10 +28,10 @@ module.exports = [
       return 'propulsion.' + skEngineId(n2k) + '.trip.fuelRate.economy'
     },
     value: function (n2k) {
-      return n2k.fields['Fuel Rate, Economy'] / 1000
+      return n2k.fields.fuelRateEconomy / 1000
     },
     filter: function (n2k) {
-      return typeof n2k.fields['Fuel Rate, Economy'] !== 'undefined'
+      return typeof n2k.fields.fuelRateEconomy !== 'undefined'
     }
   },
   {
@@ -41,10 +41,10 @@ module.exports = [
       )
     },
     value: function (n2k) {
-      return n2k.fields['Instantaneous Fuel Economy'] / 1000
+      return n2k.fields.instantaneousFuelEconomy / 1000
     },
     filter: function (n2k) {
-      return typeof n2k.fields['Instantaneous Fuel Economy'] !== 'undefined'
+      return typeof n2k.fields.instantaneousFuelEconomy !== 'undefined'
     }
   }
 ]

--- a/pgns/127501.js
+++ b/pgns/127501.js
@@ -2,10 +2,10 @@ module.exports = [
   function (n2k) {
     var res = []
     for (var i = 1; i <= 28; i++) {
-      const field = 'Indicator' + i
+      const field = 'indicator' + i
       if (typeof n2k.fields[field] !== 'undefined') {
         const basePath =
-          'electrical.switches.bank.' + n2k.fields['Instance'] + '.' + i
+          'electrical.switches.bank.' + n2k.fields.instance + '.' + i
 
         res.push({
           path: basePath + '.state',

--- a/pgns/127503.js
+++ b/pgns/127503.js
@@ -1,10 +1,10 @@
 function instance (n2k) {
-  return n2k.fields['Instance']
+  return n2k.fields['instance']
 }
 
 function acPhase (lineData) {
   const phaseMap = { 0: 'A', 1: 'B', 2: 'C' }
-  return phaseMap[lineData.Line] ?? 'A'
+  return phaseMap[lineData.line] ?? 'A'
 }
 
 function prefix (n2k, lineData) {
@@ -14,14 +14,14 @@ function prefix (n2k, lineData) {
 module.exports = [
   function (n2k, stage) {
     const fields = {
-      Acceptability: 'acceptability',
-      Voltage: 'voltage',
-      Current: 'current',
-      Frequency: 'frequency',
-      'Breaker Size': 'breakerSize',
-      'Real Power': 'realPower',
-      'Reactive Power': 'reactivePower',
-      'Power Factor': 'powerFactor'
+      acceptability: 'acceptability',
+      voltage: 'voltage',
+      current: 'current',
+      frequency: 'frequency',
+      breakerSize: 'breakerSize',
+      realPower: 'realPower',
+      reactivePower: 'reactivePower',
+      powerFactor: 'powerFactor'
     }
     return n2k.fields.list
       ? n2k.fields.list.reduce((updates, lineData) => {

--- a/pgns/127504.js
+++ b/pgns/127504.js
@@ -1,10 +1,10 @@
 function instance (n2k) {
-  return n2k.fields['Instance']
+  return n2k.fields.instance
 }
 
 function acPhase (lineData) {
   const phaseMap = { 0: 'A', 1: 'B', 2: 'C' }
-  return phaseMap[lineData.Line] ?? 'A'
+  return phaseMap[lineData.line] ?? 'A'
 }
 
 function prefix (n2k, lineData) {
@@ -14,14 +14,14 @@ function prefix (n2k, lineData) {
 module.exports = [
   function (n2k, stage) {
     const fields = {
-      Waveform: 'waveform',
-      Voltage: 'voltage',
-      Current: 'current',
-      Frequency: 'frequency',
-      'Breaker Size': 'breakerSize',
-      'Real Power': 'realPower',
-      'Reactive Power': 'reactivePower',
-      'Power Factor': 'powerFactor'
+      waveform: 'waveform',
+      voltage: 'voltage',
+      current: 'current',
+      frequency: 'frequency',
+      breakerSize: 'breakerSize',
+      realPower: 'realPower',
+      reactivePower: 'reactivePower',
+      powerFactor: 'powerFactor'
     }
     return n2k.fields.list
       ? n2k.fields.list.reduce((updates, lineData) => {

--- a/pgns/127505.js
+++ b/pgns/127505.js
@@ -3,14 +3,14 @@ module.exports = [
     node: function (n2k) {
       return (
         'tanks.' +
-        tankMappings[n2k.fields['Type']] +
+        tankMappings[n2k.fields.type] +
         '.' +
-        n2k.fields['Instance'] +
+        n2k.fields.instance +
         '.currentLevel'
       )
     },
     value: function (n2k) {
-      var ratio100 = Number(n2k.fields['Level'])
+      var ratio100 = Number(n2k.fields.level)
       return ratio100 / 100
     }
   },
@@ -18,18 +18,18 @@ module.exports = [
     node: function (n2k) {
       return (
         'tanks.' +
-        tankMappings[n2k.fields['Type']] +
+        tankMappings[n2k.fields.type] +
         '.' +
-        n2k.fields['Instance'] +
+        n2k.fields.instance +
         '.capacity'
       )
     },
     value: function (n2k) {
-      var value = Number(n2k.fields['Capacity'])
+      var value = Number(n2k.fields.capacity)
       return value / 1000
     },
     filter: n2k => {
-      return typeof n2k.fields['Capacity'] !== 'undefined'
+      return typeof n2k.fields.capacity !== 'undefined'
     }
   }
 ]

--- a/pgns/127506.js
+++ b/pgns/127506.js
@@ -1,23 +1,23 @@
 const { chooseField, timeToSeconds } = require('../utils.js')
 
 function instance (n2k) {
-  return chooseField(n2k, 'DC Instance', 'Instance')
+  return n2k.fields.instance
 }
 
 module.exports = [
   {
     value: function (n2k) {
-      return n2k.fields['State of Charge'] / 100
+      return n2k.fields.stateOfCharge / 100
     },
     filter: function (n2k) {
-      return typeof n2k.fields['State of Charge'] !== 'undefined'
+      return typeof n2k.fields.stateOfCharge !== 'undefined'
     },
     node: function (n2k) {
       return 'electrical.batteries.' + instance(n2k) + '.capacity.stateOfCharge'
     }
   },
   {
-    source: 'State of Health',
+    source: 'stateOfHealth',
     node: function (n2k) {
       return 'electrical.batteries.' + instance(n2k) + '.capacity.stateOfHealth'
     }
@@ -25,7 +25,7 @@ module.exports = [
   {
     allowNull: true,
     value: function (n2k) {
-      return timeToSeconds(n2k.fields['Time Remaining'])
+      return timeToSeconds(n2k.fields.timeRemaining)
     },
     node: function (n2k) {
       return 'electrical.batteries.' + instance(n2k) + '.capacity.timeRemaining'

--- a/pgns/127508.js
+++ b/pgns/127508.js
@@ -1,24 +1,24 @@
 const { chooseField } = require('../utils.js')
 
 function instance (n2k) {
-  return chooseField(n2k, 'Battery Instance', 'Instance')
+  return n2k.fields.instance
 }
 
 module.exports = [
   {
-    source: 'Voltage',
+    source: 'voltage',
     node: function (n2k) {
       return 'electrical.batteries.' + instance(n2k) + '.voltage'
     }
   },
   {
-    source: 'Current',
+    source: 'current',
     node: function (n2k) {
       return 'electrical.batteries.' + instance(n2k) + '.current'
     }
   },
   {
-    source: 'Temperature',
+    source: 'temperature',
     node: function (n2k) {
       return 'electrical.batteries.' + instance(n2k) + '.temperature'
     }

--- a/pgns/127750.js
+++ b/pgns/127750.js
@@ -1,31 +1,31 @@
 function prefix (n2k) {
-  return `electrical.converter.${n2k.src}.${n2k.fields['Connection Number']}`
+  return `electrical.converter.${n2k.src}.${n2k.fields.connectionNumber}`
 }
 
 module.exports = [
   {
     node: n2k => prefix(n2k) + '.operatingState',
-    value: n2k => n2k.fields['Operating State'].toLowerCase(),
-    filter: n2k => typeof n2k.fields['Operating State'] === 'string'
+    value: n2k => n2k.fields.operatingState.toLowerCase(),
+    filter: n2k => typeof n2k.fields.operatingState === 'string'
   },
   {
     node: n2k => prefix(n2k) + '.temperatureState',
-    value: n2k => n2k.fields['Temperature State'].toLowerCase(),
-    filter: n2k => typeof n2k.fields['Temperature State'] === 'string'
+    value: n2k => n2k.fields.temperatureState.toLowerCase(),
+    filter: n2k => typeof n2k.fields.temperatureState === 'string'
   },
   {
     node: n2k => prefix(n2k) + '.overloadState',
-    value: n2k => n2k.fields['Overload State'].toLowerCase(),
-    filter: n2k => typeof n2k.fields['Overload State'] === 'string'
+    value: n2k => n2k.fields.overloadState.toLowerCase(),
+    filter: n2k => typeof n2k.fields.overloadState === 'string'
   },
   {
     node: n2k => prefix(n2k) + '.lowDCVoltageState',
-    value: n2k => n2k.fields['Low DC Voltage State'].toLowerCase(),
-    filter: n2k => typeof n2k.fields['Low DC Voltage State'] === 'string'
+    value: n2k => n2k.fields.lowDcVoltageState.toLowerCase(),
+    filter: n2k => typeof n2k.fields.lowDcVoltageState === 'string'
   },
   {
     node: n2k => prefix(n2k) + '.rippleState',
-    value: n2k => n2k.fields['Ripple State'].toLowerCase(),
-    filter: n2k => typeof n2k.fields['Ripple State'] === 'string'
+    value: n2k => n2k.fields.rippleState.toLowerCase(),
+    filter: n2k => typeof n2k.fields.rippleState === 'string'
   }
 ]

--- a/pgns/127751.js
+++ b/pgns/127751.js
@@ -1,14 +1,14 @@
 function prefix (n2k) {
-  return `electrical.dc.${n2k.src}.${n2k.fields['Connection Number']}`
+  return `electrical.dc.${n2k.src}.${n2k.fields.connectionNumber}`
 }
 
 module.exports = [
   {
-    source: 'DC Voltage',
+    source: 'dcVoltage',
     node: n2k => prefix(n2k) + '.voltage'
   },
   {
-    source: 'DC Current',
+    source: 'dcCurrent',
     node: n2k => prefix(n2k) + '.current'
   }
 ]

--- a/pgns/128259.js
+++ b/pgns/128259.js
@@ -1,23 +1,23 @@
 module.exports = [
   {
-    source: 'Speed Water Referenced',
+    source: 'speedWaterReferenced',
     node: 'navigation.speedThroughWater',
     filter: function (n2k) {
-      return typeof n2k.fields['Speed Water Referenced'] !== 'undefined'
+      return typeof n2k.fields.speedWaterReferenced !== 'undefined'
     }
   },
   {
-    source: 'Speed Ground Referenced',
+    source: 'speedGroundReferenced',
     node: 'navigation.speedOverGround',
     filter: function (n2k) {
-      return n2k.fields['Speed Ground Referenced']
+      return n2k.fields.speedGroundReferenced
     }
   },
   {
-    source: 'Speed Water Referenced Type',
+    source: 'speedWaterReferencedType',
     node: 'navigation.speedThroughWaterReferenceType',
     filter: function (n2k) {
-      return n2k.fields['Speed Water Referenced Type']
+      return n2k.fields.speedWaterReferencedType
     }
   }
 ]

--- a/pgns/128267.js
+++ b/pgns/128267.js
@@ -1,23 +1,23 @@
 module.exports = [
   {
-    source: 'Depth',
+    source: 'depth',
     node: 'environment.depth.belowTransducer'
   },
   {
-    source: 'Offset',
+    source: 'offset',
     node: 'environment.depth.surfaceToTransducer',
     filter: function (n2k) {
       return (
-        typeof n2k.fields['Offset'] !== 'undefined' && n2k.fields['Offset'] > 0
+        typeof n2k.fields.offset !== 'undefined' && n2k.fields.offset > 0
       )
     }
   },
   {
-    source: 'Offset',
+    source: 'offset',
     node: 'environment.depth.transducerToKeel',
     filter: function (n2k) {
       return (
-        typeof n2k.fields['Offset'] !== 'undefined' && n2k.fields['Offset'] < 0
+        typeof n2k.fields.offset !== 'undefined' && n2k.fields.offset < 0
       )
     }
   },
@@ -25,26 +25,26 @@ module.exports = [
     node: 'environment.depth.belowSurface',
     filter: function (n2k) {
       return (
-        typeof n2k.fields['Depth'] !== 'undefined' &&
-        typeof n2k.fields['Offset'] !== 'undefined' &&
-        n2k.fields['Offset'] > 0
+        typeof n2k.fields.depth !== 'undefined' &&
+        typeof n2k.fields.offset !== 'undefined' &&
+        n2k.fields.offset > 0
       )
     },
     value: function (n2k) {
-      return Number(n2k.fields.Depth) + Number(n2k.fields.Offset)
+      return Number(n2k.fields.depth) + Number(n2k.fields.offset)
     }
   },
   {
     node: 'environment.depth.belowKeel',
     filter: function (n2k) {
       return (
-        typeof n2k.fields['Depth'] !== 'undefined' &&
-        typeof n2k.fields['Offset'] !== 'undefined' &&
-        n2k.fields['Offset'] < 0
+        typeof n2k.fields.depth !== 'undefined' &&
+        typeof n2k.fields.offset !== 'undefined' &&
+        n2k.fields.offset < 0
       )
     },
     value: function (n2k) {
-      return Number(n2k.fields.Depth) + Number(n2k.fields.Offset)
+      return Number(n2k.fields.depth) + Number(n2k.fields.offset)
     }
   }
 ]

--- a/pgns/128275.js
+++ b/pgns/128275.js
@@ -1,10 +1,10 @@
 module.exports = [
   {
-    source: 'Trip Log',
+    source: 'tripLog',
     node: 'navigation.trip.log'
   },
   {
-    source: 'Log',
+    source: 'log',
     node: 'navigation.log'
   }
 ]

--- a/pgns/129025.js
+++ b/pgns/129025.js
@@ -2,14 +2,14 @@ module.exports = [
   {
     value: function (n2k) {
       return {
-        longitude: Number(n2k.fields.Longitude),
-        latitude: Number(n2k.fields.Latitude)
+        longitude: Number(n2k.fields.longitude),
+        latitude: Number(n2k.fields.latitude)
       }
     },
     filter: function (n2k) {
       return (
-        typeof n2k.fields['Longitude'] !== 'undefined' &&
-        typeof n2k.fields['Latitude'] !== 'undefined'
+        typeof n2k.fields.longitude !== 'undefined' &&
+        typeof n2k.fields.latitude !== 'undefined'
       )
     },
     node: 'navigation.position'

--- a/pgns/129026.js
+++ b/pgns/129026.js
@@ -1,20 +1,20 @@
 module.exports = [
   {
-    source: 'SOG',
+    source: 'sog',
     node: 'navigation.speedOverGround'
   },
   {
-    source: 'COG',
+    source: 'cog',
     node: 'navigation.courseOverGroundTrue',
     filter: function (n2k) {
-      return n2k.fields['COG Reference'] === 'True'
+      return n2k.fields.cogReference === 'True'
     }
   },
   {
-    source: 'COG',
+    source: 'cog',
     node: 'navigation.courseOverGroundMagnetic',
     filter: function (n2k) {
-      return n2k.fields['COG Reference'] === 'Magnetic'
+      return n2k.fields.cogReference === 'Magnetic'
     }
   }
 ]

--- a/pgns/129029.js
+++ b/pgns/129029.js
@@ -2,56 +2,56 @@ module.exports = [
   {
     value: function (n2k) {
       return {
-        longitude: Number(n2k.fields.Longitude),
-        latitude: Number(n2k.fields.Latitude)
+        longitude: Number(n2k.fields.longitude),
+        latitude: Number(n2k.fields.latitude)
       }
     },
     filter: n2k =>
-      typeof n2k.fields.Longitude !== 'undefined' &&
-      typeof n2k.fields.Latitude !== 'undefined',
+      typeof n2k.fields.longitude !== 'undefined' &&
+      typeof n2k.fields.latitude !== 'undefined',
     node: 'navigation.position'
   },
   {
     value: function (n2k) {
-      return `${n2k.fields.Date.replace(/\./g, '-')}T${n2k.fields.Time}Z`
+      return `${n2k.fields.date.replace(/\./g, '-')}T${n2k.fields.time}Z`
     },
     filter: n2k =>
-      typeof n2k.fields.Date !== 'undefined' &&
-      typeof n2k.fields.Time !== 'undefined',
+      typeof n2k.fields.date !== 'undefined' &&
+      typeof n2k.fields.time !== 'undefined',
     node: 'navigation.datetime'
   },
   {
-    source: 'Altitude',
+    source: 'altitude',
     node: 'navigation.gnss.antennaAltitude'
   },
   {
-    source: 'Number of SVs',
+    source: 'numberOfSvs',
     node: 'navigation.gnss.satellites'
   },
   {
-    source: 'HDOP',
+    source: 'hdop',
     node: 'navigation.gnss.horizontalDilution'
   },
   {
-    source: 'PDOP',
+    source: 'pdop',
     node: 'navigation.gnss.positionDilution'
   },
   {
-    source: 'Geoidal Separation',
+    source: 'geoidalSeparation',
     node: 'navigation.gnss.geoidalSeparation'
   },
   {
-    source: 'Age of DGNSS Corrections',
+    source: 'ageOfDgnssCorrections',
     node: 'navigation.gnss.differentialAge'
   },
   {
-    source: 'Reference Station ID',
+    source: 'referenceStationId',
     node: 'navigation.gnss.differentialReference'
   },
   {
     node: 'navigation.gnss.type',
     value: function (n2k) {
-      var type = n2k.fields['GNSS type']
+      var type = n2k.fields.gnssType
       var mapped = typeMap[type]
       return mapped || type
     }
@@ -59,7 +59,7 @@ module.exports = [
   {
     node: 'navigation.gnss.methodQuality',
     value: function (n2k) {
-      var method = n2k.fields['Method']
+      var method = n2k.fields.method
       var mapped = methodQualityMap[method]
       return mapped || method
     }
@@ -67,7 +67,7 @@ module.exports = [
   {
     node: 'navigation.gnss.integrity',
     value: function (n2k) {
-      var integrity = n2k.fields['Integrity']
+      var integrity = n2k.fields.integrity
       var mapped = integrityMap[integrity]
       return mapped || integrity
     }

--- a/pgns/129038.js
+++ b/pgns/129038.js
@@ -2,55 +2,55 @@ const getMmsiContext = require('../mmsi-context').getMmsiContext
 
 module.exports = [
   {
-    source: 'SOG',
+    source: 'sog',
     node: 'navigation.speedOverGround'
   },
   {
-    source: 'COG',
+    source: 'cog',
     node: 'navigation.courseOverGroundTrue'
   },
   {
-    filter: n2k => n2k.fields.Longitude && n2k.fields.Latitude,
+    filter: n2k => n2k.fields.longitude && n2k.fields.latitude,
     value: function (n2k) {
       return {
-        longitude: Number(n2k.fields.Longitude),
-        latitude: Number(n2k.fields.Latitude)
+        longitude: Number(n2k.fields.longitude),
+        latitude: Number(n2k.fields.latitude)
       }
     },
     node: 'navigation.position'
   },
   {
-    source: 'Rate of Turn',
+    source: 'rateOfTurn',
     node: 'navigation.rateOfTurn'
   },
   {
-    source: 'Heading',
+    source: 'heading',
     node: 'navigation.headingTrue'
   },
   {
     node: 'navigation.state',
     value: function (n2k) {
-      return stateMapping[n2k.fields['Nav Status']]
+      return stateMapping[n2k.fields.navStatus]
     },
     filter: function (n2k) {
-      return n2k.fields['Nav Status']
+      return n2k.fields.navStatus
     }
   },
   {
     node: 'navigation.specialManeuver',
     value: function (n2k) {
-      return specialManeuverMapping[n2k.fields['Special Maneuver Indicator']]
+      return specialManeuverMapping[n2k.fields.specialManeuverIndicator]
     },
     filter: function (n2k) {
-      return n2k.fields['Special Maneuver Indicator']
+      return n2k.fields.specialManeuverIndicator
     }
   },
   {
     node: '',
-    filter: n2k => n2k.fields['User ID'],
+    filter: n2k => n2k.fields.userId,
     value: function (n2k) {
       return {
-        mmsi: n2k.fields['User ID'].toString()
+        mmsi: n2k.fields.userId.toString()
       }
     }
   },

--- a/pgns/129039.js
+++ b/pgns/129039.js
@@ -2,33 +2,33 @@ const getMmsiContext = require('../mmsi-context').getMmsiContext
 
 module.exports = [
   {
-    source: 'SOG',
+    source: 'sog',
     node: 'navigation.speedOverGround'
   },
   {
-    source: 'COG',
+    source: 'cog',
     node: 'navigation.courseOverGroundTrue'
   },
   {
-    filter: n2k => n2k.fields.Longitude && n2k.fields.Latitude,
+    filter: n2k => n2k.fields.longitude && n2k.fields.latitude,
     value: function (n2k) {
       return {
-        longitude: Number(n2k.fields.Longitude),
-        latitude: Number(n2k.fields.Latitude)
+        longitude: Number(n2k.fields.longitude),
+        latitude: Number(n2k.fields.latitude)
       }
     },
     node: 'navigation.position'
   },
   {
-    source: 'Heading',
+    source: 'heading',
     node: 'navigation.headingTrue'
   },
   {
     node: '',
-    filter: n2k => n2k.fields['User ID'],
+    filter: n2k => n2k.fields.userId,
     value: function (n2k) {
       return {
-        mmsi: n2k.fields['User ID'].toString()
+        mmsi: n2k.fields.userId.toString()
       }
     }
   },

--- a/pgns/129040.js
+++ b/pgns/129040.js
@@ -5,80 +5,80 @@ const getShipType = require('../aisShipTypeMapping')
 module.exports = [
   {
     node: '',
-    filter: n2k => n2k.fields.Name,
+    filter: n2k => n2k.fields.name,
     value: function (n2k) {
       return {
-        name: n2k.fields.Name
+        name: n2k.fields.name
       }
     }
   },
   {
-    source: 'Destination',
+    source: 'destination',
     node: 'navigation.destination.commonName'
   },
   {
-    filter: n2k => n2k.fields.Longitude && n2k.fields.Latitude,
+    filter: n2k => n2k.fields.longitude && n2k.fields.latitude,
     value: function (n2k) {
       return {
-        longitude: Number(n2k.fields.Longitude),
-        latitude: Number(n2k.fields.Latitude)
+        longitude: Number(n2k.fields.longitude),
+        latitude: Number(n2k.fields.latitude)
       }
     },
     node: 'navigation.position'
   },
   {
-    source: 'SOG',
+    source: 'sog',
     node: 'navigation.speedOverGround'
   },
   {
-    source: 'COG',
+    source: 'cog',
     node: 'navigation.courseOverGroundTrue'
   },
   {
-    source: 'True Heading',
+    source: 'trueHeading',
     node: 'navigation.headingTrue'
   },
   {
     node: 'design.length',
     value: function (n2k) {
-      return { overall: Number(n2k.fields.Length) }
+      return { overall: Number(n2k.fields.length) }
     },
     filter: function (n2k) {
-      return n2k.fields['Length']
+      return n2k.fields.length
     }
   },
   {
     node: 'design.aisShipType',
     value: function (n2k) {
-      return getShipType(n2k.fields['Type of ship'])
+      return getShipType(n2k.fields.typeOfShip)
     },
     filter: function (n2k) {
-      return n2k.fields['Type of ship']
+      return n2k.fields.typeOfShip
     }
   },
   {
     node: 'design.beam',
-    source: 'Beam'
+    source: 'beam'
   },
   {
     node: 'sensors.ais.fromBow',
-    source: 'Position reference from Bow'
+    source: 'positionReferenceFromBow'
   },
   {
     node: 'sensors.ais.fromCenter',
     value: getFromStarboard,
     filter: function (n2k) {
       return (
-        n2k.fields['Position reference from Starboard'] && n2k.fields['Beam']
+        n2k.fields.positionReferenceFromStarboard && n2k.fields.beam
       )
     }
   },
   {
     node: '',
-    filter: n2k => n2k.fields['User ID'],
+    filter: n2k => n2k.fields.userId,
     value: function (n2k) {
       return {
-        mmsi: n2k.fields['User ID'].toString()
+        mmsi: n2k.fields.userId.toString()
       }
     }
   },

--- a/pgns/129041.js
+++ b/pgns/129041.js
@@ -5,19 +5,19 @@ const schema = require('@signalk/signalk-schema')
 module.exports = [
   {
     node: '',
-    filter: n2k => n2k.fields['AtoN Name'],
+    filter: n2k => n2k.fields.atonName,
     value: function (n2k) {
       return {
-        name: n2k.fields['AtoN Name']
+        name: n2k.fields.atonName
       }
     }
   },
   {
-    filter: n2k => n2k.fields.Longitude && n2k.fields.Latitude,
+    filter: n2k => n2k.fields.longitude && n2k.fields.latitude,
     value: function (n2k) {
       return {
-        longitude: Number(n2k.fields.Longitude),
-        latitude: Number(n2k.fields.Latitude)
+        longitude: Number(n2k.fields.longitude),
+        latitude: Number(n2k.fields.latitude)
       }
     },
     node: 'navigation.position'
@@ -25,16 +25,16 @@ module.exports = [
   {
     node: 'design.length',
     value: function (n2k) {
-      return { overall: Number(n2k.fields['Length/Diameter']) }
+      return { overall: Number(n2k.fields.lengthDiameter) }
     },
     filter: function (n2k) {
-      return n2k.fields['Length/Diameter']
+      return n2k.fields.lengthDiameter
     }
   },
   {
     node: 'atonType',
     value: function (n2k) {
-      const num = nameMapping[n2k.fields['AtoN Type']]
+      const num = nameMapping[n2k.fields.atonType]
       if (typeof num !== 'undefined' && (name = schema.getAtonTypeName(num))) {
         return {
           id: num,
@@ -47,49 +47,49 @@ module.exports = [
   },
   {
     node: 'design.beam',
-    source: 'Beam/Diameter'
+    source: 'beamDiameter'
   },
   {
     node: 'sensors.ais.fromBow',
-    source: 'Position reference from Bow'
+    source: 'positionReferenceFromBow'
   },
   {
     node: 'sensors.ais.fromCenter',
     value: getFromStarboard,
     filter: function (n2k) {
       return (
-        n2k.fields['Position reference from Starboard'] &&
-        n2k.fields['Beam/Diameter']
+        n2k.fields.positionReferenceFromStarboard &&
+        n2k.fields.beamDiameter
       )
     }
   },
   {
     node: 'virtual',
     value: function (n2k) {
-      const flag = n2k.fields['Virtual AtoN Flag']
+      const flag = n2k.fields.virtualAtonFlag
       return typeof flag != 'undefined' ? flag === 'Yes' : undefined
     }
   },
   {
     node: 'offPosition',
     value: function (n2k) {
-      const flag = n2k.fields['Off Position Indicator']
+      const flag = n2k.fields.offPositionIndicator
       return typeof flag != 'undefined' ? flag === 'Yes' : undefined
     }
   },
   {
     node: '',
-    filter: n2k => n2k.fields['User ID'],
+    filter: n2k => n2k.fields.userId,
     value: function (n2k) {
       return {
-        mmsi: n2k.fields['User ID'].toString()
+        mmsi: n2k.fields.userId.toString()
       }
     }
   },
   {
     context: function (n2k) {
-      return n2k.fields['User ID']
-        ? 'atons.urn:mrn:imo:mmsi:' + n2k.fields['User ID']
+      return n2k.fields.userId
+        ? 'atons.urn:mrn:imo:mmsi:' + n2k.fields.userId
         : undefined
     }
   },

--- a/pgns/129283.js
+++ b/pgns/129283.js
@@ -11,13 +11,13 @@ module.exports = [
     },
     filter: function (n2k, state) {
       return (
-        n2k.fields['Navigation Terminated'] &&
-        n2k.fields['Navigation Terminated'] === 'No' &&
-        typeof n2k.fields['XTE'] !== 'undefined' &&
+        n2k.fields.navigationTerminated &&
+        n2k.fields.navigationTerminated === 'No' &&
+        typeof n2k.fields.xte !== 'undefined' &&
         typeof state === 'object' &&
         typeof state.lastCourseCalculationType !== 'undefined'
       )
     },
-    source: 'XTE'
+    source: 'xte'
   }
 ]

--- a/pgns/129284.js
+++ b/pgns/129284.js
@@ -1,12 +1,10 @@
 const debug = require('debug')('n2k-signalk-129284')
 
-var CALCULATION_TYPE = 'Calculation Type'
-var RHUMBLINE = 'Rhumb Line'
 var GREATCIRCLE = 'Great Circle'
 
 function calculationType (n2k, state) {
   var res =
-    n2k.fields[CALCULATION_TYPE] === GREATCIRCLE ? 'GreatCircle' : 'Rhumbline'
+    n2k.fields.calculationType === GREATCIRCLE ? 'GreatCircle' : 'Rhumbline'
   debug('set calculationType to: ' + res)
   if (typeof state !== 'undefined') state.lastCourseCalculationType = res
   return res
@@ -19,10 +17,10 @@ module.exports = [
         'navigation.course' +
         calculationType(n2k, state) +
         '.bearingTrack' +
-        n2k.fields['Course/Bearing reference']
+        n2k.fields.courseBearingReference
       )
     },
-    source: 'Bearing, Origin to Destination Waypoint'
+    source: 'bearingOriginToDestinationWaypoint'
   },
   {
     node: function (n2k, state) {
@@ -32,7 +30,7 @@ module.exports = [
         '.nextPoint.distance'
       )
     },
-    source: 'Distance to Waypoint'
+    source: 'distanceToWaypoint'
   },
   {
     node: function (n2k, state) {
@@ -42,7 +40,7 @@ module.exports = [
         '.nextPoint.velocityMadeGood'
       )
     },
-    source: 'Waypoint Closing Velocity'
+    source: 'waypointClosingVelocity'
   },
   {
     node: function (n2k, state) {
@@ -50,10 +48,10 @@ module.exports = [
         'navigation.course' +
         calculationType(n2k, state) +
         '.nextPoint.bearing' +
-        n2k.fields['Course/Bearing reference']
+        n2k.fields.courseBearingReference
       )
     },
-    source: 'Bearing, Position to Destination Waypoint'
+    source: 'bearingPositionToDestinationWaypoint'
   },
   {
     node: function (n2k, state) {
@@ -65,8 +63,8 @@ module.exports = [
     },
     value: function (n2k) {
       return {
-        longitude: Number(n2k.fields['Destination Longitude']),
-        latitude: Number(n2k.fields['Destination Latitude'])
+        longitude: Number(n2k.fields.destinationLongitude),
+        latitude: Number(n2k.fields.destinationLatitude)
       }
     }
   },
@@ -75,13 +73,13 @@ module.exports = [
       return 'navigation.course' + calculationType(n2k) + '.nextPoint.timeToGo'
     },
     filter: function (n2k) {
-      return n2k.fields['ETA Date'] && n2k.fields['ETA Time']
+      return n2k.fields.etaDate && n2k.fields.etaTime
     },
     value: function (n2k) {
       var dateStr =
-        n2k.fields['ETA Date'].replace(/\./g, '-') +
+        n2k.fields.etaDate.replace(/\./g, '-') +
         'T' +
-        n2k.fields['ETA Time'] +
+        n2k.fields.etaTime +
         'Z'
       var eta = new Date(dateStr)
       var now = new Date(n2k.timestamp)

--- a/pgns/129285.js
+++ b/pgns/129285.js
@@ -4,7 +4,7 @@ const _ = require('lodash')
 module.exports = [
   {
     node: 'navigation.currentRoute.name',
-    source: 'Route Name'
+    source: 'routeName'
   },
   {
     node: 'navigation.currentRoute.waypoints',
@@ -15,11 +15,11 @@ module.exports = [
       var idx = 0
       return n2k.fields.list.map(wp => {
         return {
-          name: wp['WP Name'],
+          name: wp.wpName,
           position: {
             value: {
-              latitude: wp['WP Latitude'],
-              longitude: wp['WP Longitude']
+              latitude: wp.wpLatitude,
+              longitude: wp.wpLongitude
             }
           }
         }

--- a/pgns/129291.js
+++ b/pgns/129291.js
@@ -2,16 +2,16 @@ module.exports = [
   {
     node: 'environment.current',
     value: function (n2k) {
-      if (n2k.fields['Set Reference'] === 'True') {
+      if (n2k.fields.setReference === 'True') {
         return {
-          setTrue: Number(n2k.fields.Set),
-          drift: Number(n2k.fields['Drift'])
+          setTrue: Number(n2k.fields.set),
+          drift: Number(n2k.fields.drift)
         }
-      } else if (n2k.fields['Set Reference'] === 'Magnetic') {
+      } else if (n2k.fields.setReference === 'Magnetic') {
         // speculative, I don't have a real world sample showing 'Magnetic'
         return {
-          setTrue: Number(n2k.fields.Set),
-          drift: Number(n2k.fields['Drift'])
+          setTrue: Number(n2k.fields.set),
+          drift: Number(n2k.fields.drift)
         }
       }
     }

--- a/pgns/129793.js
+++ b/pgns/129793.js
@@ -6,21 +6,21 @@ module.exports = [
   {
     value: function (n2k) {
       return {
-        longitude: Number(n2k.fields.Longitude),
-        latitude: Number(n2k.fields.Latitude)
+        longitude: Number(n2k.fields.longitude),
+        latitude: Number(n2k.fields.latitude)
       }
     },
     filter: function (n2k) {
       return (
-        typeof n2k.fields['Longitude'] !== 'undefined' &&
-        typeof n2k.fields['Latitude'] !== 'undefined'
+        typeof n2k.fields.longitude !== 'undefined' &&
+        typeof n2k.fields.latitude !== 'undefined'
       )
     },
     node: 'navigation.position'
   },
   {
     node: '',
-    filter: n2k => n2k.fields['User ID'],
+    filter: n2k => n2k.fields.userId,
     value: function (n2k) {
       return {
         mmsi: padUserID(n2k)
@@ -29,7 +29,7 @@ module.exports = [
   },
   {
     context: function (n2k) {
-      return typeof n2k.fields['User ID'] !== 'undefined'
+      return typeof n2k.fields.userId !== 'undefined'
         ? 'shore.basestations.urn:mrn:imo:mmsi:' + padUserID(n2k)
         : undefined
     }

--- a/pgns/129794.js
+++ b/pgns/129794.js
@@ -11,76 +11,76 @@ module.exports = [
   },
   {
     node: '',
-    filter: n2k => n2k.fields.Name,
+    filter: n2k => n2k.fields.name,
     value: function (n2k) {
       return {
-        name: n2k.fields.Name
+        name: n2k.fields.name
       }
     }
   },
   {
     node: 'navigation.destination.commonName',
-    value: n2k => n2k.fields['Destination']
+    value: n2k => n2k.fields.destination
   },
   {
     node: 'design.draft',
     filter: function (n2k) {
-      return n2k.fields['Draft']
+      return n2k.fields.draft
     },
     value: function (n2k) {
-      return { maximum: n2k.fields['Draft'] }
+      return { maximum: n2k.fields.draft }
     }
   },
   {
     node: 'design.length',
     value: function (n2k) {
-      return { overall: Number(n2k.fields.Length) }
+      return { overall: Number(n2k.fields.length) }
     },
     filter: function (n2k) {
-      return n2k.fields['Length']
+      return n2k.fields.length
     }
   },
   {
     node: 'design.aisShipType',
     value: function (n2k) {
-      return getShipType(n2k.fields['Type of ship'])
+      return getShipType(n2k.fields.typeOfShip)
     },
     filter: function (n2k) {
-      return n2k.fields['Type of ship']
+      return n2k.fields.typeOfShip
     }
   },
   {
     node: '',
-    filter: n2k => n2k.fields['Callsign'],
+    filter: n2k => n2k.fields.callsign,
     value: n2k => ({
       communication: {
-        callsignVhf: n2k.fields['Callsign']
+        callsignVhf: n2k.fields.callsign
       }
     })
   },
   {
     node: 'design.beam',
-    source: 'Beam'
+    source: 'beam'
   },
   {
     node: 'sensors.ais.fromBow',
-    source: 'Position reference from Bow'
+    source: 'positionReferenceFromBow'
   },
   {
     node: 'sensors.ais.fromCenter',
     value: getFromStarboard,
     filter: function (n2k) {
       return (
-        n2k.fields['Position reference from Starboard'] && n2k.fields['Beam']
+        n2k.fields.positionReferenceFromStarboard && n2k.fields.beam
       )
     }
   },
   {
     node: '',
-    filter: n2k => n2k.fields['User ID'],
+    filter: n2k => n2k.fields.userId,
     value: function (n2k) {
       return {
-        mmsi: n2k.fields['User ID'].toString()
+        mmsi: n2k.fields.userId.toString()
       }
     }
   },
@@ -89,12 +89,12 @@ module.exports = [
     value: function (n2k) {
       return {
         registrations: {
-          imo: `IMO ${n2k.fields['IMO number']}`
+          imo: `IMO ${n2k.fields.imoNumber}`
         }
       }
     },
     filter: function (n2k) {
-      return n2k.fields['IMO number'] && n2k.fields['IMO number'] != 0
+      return n2k.fields.imoNumber && n2k.fields.imoNumber != 0
     }
   },
   {

--- a/pgns/129798.js
+++ b/pgns/129798.js
@@ -2,22 +2,22 @@ const padUserID = require('../mmsi-context').padUserID
 
 module.exports = [
   {
-    source: 'SOG',
+    source: 'sog',
     node: 'navigation.speedOverGround'
   },
   {
-    source: 'COG',
+    source: 'cog',
     node: 'navigation.courseOverGroundTrue'
   },
   {
-    filter: n2k => n2k.fields.Longitude && n2k.fields.Latitude,
+    filter: n2k => n2k.fields.longitude && n2k.fields.latitude,
     value: function (n2k) {
       var res = {
-        longitude: Number(n2k.fields.Longitude),
-        latitude: Number(n2k.fields.Latitude)
+        longitude: Number(n2k.fields.longitude),
+        latitude: Number(n2k.fields.latitude)
       }
-      if (typeof n2k.fields.Altitude !== 'undefined') {
-        res.altitude = Number(n2k.fields.Altitude)
+      if (typeof n2k.fields.altitude !== 'undefined') {
+        res.altitude = Number(n2k.fields.altitude)
       }
       return res
     },
@@ -25,7 +25,7 @@ module.exports = [
   },
   {
     node: '',
-    filter: n2k => n2k.fields['User ID'],
+    filter: n2k => n2k.fields.userId,
     value: function (n2k) {
       return {
         mmsi: padUserID(n2k)
@@ -34,7 +34,7 @@ module.exports = [
   },
   {
     context: function (n2k) {
-      return typeof n2k.fields['User ID'] !== 'undefined'
+      return typeof n2k.fields.userId !== 'undefined'
         ? 'sar.urn:mrn:imo:mmsi:' + padUserID(n2k)
         : undefined
     }

--- a/pgns/129809.js
+++ b/pgns/129809.js
@@ -3,31 +3,31 @@ const getMmsiContext = require('../mmsi-context').getMmsiContext
 module.exports = [
   {
     node: 'sensors.ais.class',
-    filter: n2k => n2k.fields['User ID'],
+    filter: n2k => n2k.fields.userId,
     value: function (n2k) {
       return 'B'
     }
   },
   {
     node: '',
-    filter: n2k => n2k.fields.Name,
+    filter: n2k => n2k.fields.name,
     value: function (n2k) {
       return {
-        name: n2k.fields.Name
+        name: n2k.fields.name
       }
     }
   },
   {
     node: '',
-    filter: n2k => n2k.fields['User ID'],
+    filter: n2k => n2k.fields.userId,
     value: function (n2k) {
       return {
-        mmsi: n2k.fields['User ID'].toString()
+        mmsi: n2k.fields.userId.toString()
       }
     }
   },
   {
     context: getMmsiContext,
-    filter: n2k => n2k.fields['User ID']
+    filter: n2k => n2k.fields.userId
   }
 ]

--- a/pgns/129810.js
+++ b/pgns/129810.js
@@ -6,53 +6,53 @@ module.exports = [
   {
     node: 'design.length',
     value: function (n2k) {
-      return { overall: Number(n2k.fields.Length) }
+      return { overall: Number(n2k.fields.length) }
     },
     filter: function (n2k) {
-      return n2k.fields['Length']
+      return n2k.fields.length
     }
   },
   {
     node: 'design.aisShipType',
     value: function (n2k) {
-      return getShipType(n2k.fields['Type of ship'])
+      return getShipType(n2k.fields.typeOfShip)
     },
     filter: function (n2k) {
-      return n2k.fields['Type of ship']
+      return n2k.fields.typeOfShip
     }
   },
   {
     node: 'design.beam',
-    source: 'Beam'
+    source: 'beam'
   },
   {
     node: '',
-    filter: n2k => n2k.fields['Callsign'],
+    filter: n2k => n2k.fields.callsign,
     value: n2k => ({
       communication: {
-        callsignVhf: n2k.fields['Callsign']
+        callsignVhf: n2k.fields.callsign
       }
     })
   },
   {
     node: 'sensors.ais.fromBow',
-    source: 'Position reference from Bow'
+    source: 'positionReferenceFromBow'
   },
   {
     node: 'sensors.ais.fromCenter',
     value: getFromStarboard,
     filter: function (n2k) {
       return (
-        n2k.fields['Position reference from Starboard'] && n2k.fields['Beam']
+        n2k.fields.positionReferenceFromStarboard && n2k.fields.beam
       )
     }
   },
   {
     node: '',
-    filter: n2k => n2k.fields['User ID'],
+    filter: n2k => n2k.fields.userId,
     value: function (n2k) {
       return {
-        mmsi: n2k.fields['User ID'].toString()
+        mmsi: n2k.fields.userId.toString()
       }
     }
   },

--- a/pgns/130306.js
+++ b/pgns/130306.js
@@ -1,63 +1,63 @@
 module.exports = [
   {
-    source: 'Wind Speed',
+    source: 'windSpeed',
     node: 'environment.wind.speedApparent',
     filter: function (n2k) {
       return (
-        n2k.fields['Reference'] === 'Apparent' ||
-        n2k.fields['Reference'] === undefined ||
-        n2k.fields['Reference'] === null
+        n2k.fields.reference === 'Apparent' ||
+        n2k.fields.reference === undefined ||
+        n2k.fields.reference === null
       )
     }
   },
   {
-    source: 'Wind Speed',
+    source: 'windSpeed',
     node: 'environment.wind.speedTrue',
     filter: function (n2k) {
-      return n2k.fields['Reference'] === 'True (boat referenced)'
+      return n2k.fields.reference === 'True (boat referenced)'
     }
   },
   {
-    source: 'Wind Speed',
+    source: 'windSpeed',
     node: 'environment.wind.speedOverGround',
     filter: function (n2k) {
-      return n2k.fields['Reference'] === 'True (ground referenced to North)'
+      return n2k.fields.reference === 'True (ground referenced to North)'
     }
   },
   {
     node: 'environment.wind.angleApparent',
     filter: function (n2k) {
       return (
-        n2k.fields['Reference'] === 'Apparent' ||
-        n2k.fields['Reference'] === undefined ||
-        n2k.fields['Reference'] === null
+        n2k.fields.reference === 'Apparent' ||
+        n2k.fields.reference === undefined ||
+        n2k.fields.reference === null
       )
     },
     value: function (n2k) {
-      var angle = Number(n2k.fields['Wind Angle'])
+      var angle = Number(n2k.fields.windAngle)
       return angle <= Math.PI ? angle : angle - Math.PI * 2
     }
   },
   {
-    source: 'Wind Angle',
+    source: 'windAngle',
     node: 'environment.wind.angleTrueWater',
     filter: function (n2k) {
-      return n2k.fields['Reference'] === 'True (boat referenced)'
+      return n2k.fields.reference === 'True (boat referenced)'
     }
   },
   {
-    source: 'Wind Angle',
+    source: 'windAngle',
     node: 'environment.wind.directionTrue',
     filter: function (n2k) {
-      return n2k.fields['Reference'] === 'True (ground referenced to North)'
+      return n2k.fields.reference === 'True (ground referenced to North)'
     }
   },
   {
-    source: 'Wind Angle',
+    source: 'windAngle',
     node: 'environment.wind.directionMagnetic',
     filter: function (n2k) {
       return (
-        n2k.fields['Reference'] ===
+        n2k.fields.reference ===
         'Magnetic (ground referenced to Magnetic North)'
       )
     }

--- a/pgns/130310.js
+++ b/pgns/130310.js
@@ -1,27 +1,27 @@
 module.exports = [
   {
-    source: 'Outside Ambient Air Temperature',
+    source: 'outsideAmbientAirTemperature',
     node: 'environment.outside.temperature',
     filter: function (n2k) {
-      return n2k.fields['Outside Ambient Air Temperature']
+      return n2k.fields.outsideAmbientAirTemperature
     }
   },
   {
     node: 'environment.outside.pressure',
     filter: function (n2k) {
-      return n2k.fields['Atmospheric Pressure']
+      return n2k.fields.atmosphericPressure
     },
     value: function (n2k) {
-      return Number(n2k.fields['Atmospheric Pressure'])
+      return Number(n2k.fields.atmosphericPressure)
     }
   },
   {
     node: 'environment.water.temperature',
     filter: function (n2k) {
-      return n2k.fields['Water Temperature']
+      return n2k.fields.waterTemperature
     },
     value: function (n2k) {
-      return Number(n2k.fields['Water Temperature'])
+      return Number(n2k.fields.waterTemperature)
     }
   }
 ]

--- a/pgns/130311.js
+++ b/pgns/130311.js
@@ -4,7 +4,7 @@ module.exports = [
   {
     node: function (n2k) {
       var temperatureMapping =
-        temperatureMappings[n2k.fields['Temperature Source']]
+        temperatureMappings[n2k.fields.temperatureSource]
 
       if (temperatureMapping) {
         if (temperatureMapping.pathWithIndex) {
@@ -14,32 +14,32 @@ module.exports = [
         }
       }
     },
-    source: 'Temperature'
+    source: 'temperature'
   },
   {
     node: function (n2k) {
       return (
         'environment.' +
-        (n2k.fields['Humidity Source'] === 'Inside'
+        (n2k.fields.humiditySource === 'Inside'
           ? 'inside.relativeHumidity'
           : 'outside.humidity')
       )
     },
     filter: function (n2k) {
-      return typeof n2k.fields['Humidity'] !== 'undefined'
+      return typeof n2k.fields.humidity !== 'undefined'
     },
     value: function (n2k) {
-      var ratio100 = Number(n2k.fields['Humidity'])
+      var ratio100 = Number(n2k.fields.humidity)
       return ratio100 / 100
     }
   },
   {
     node: 'environment.outside.pressure',
     filter: function (n2k) {
-      return n2k.fields['Atmospheric Pressure']
+      return n2k.fields.atmosphericPressure
     },
     value: function (n2k) {
-      return Number(n2k.fields['Atmospheric Pressure'])
+      return Number(n2k.fields.atmosphericPressure)
     }
   }
 ]

--- a/pgns/130312.js
+++ b/pgns/130312.js
@@ -1,29 +1,28 @@
 const temperatureMappings = require('../temperatureMappings')
-const { chooseField } = require('../utils.js')
 
 module.exports = [
   {
     node: function (n2k) {
       var temperatureMapping =
-        temperatureMappings[chooseField(n2k, 'Temperature Source', 'Source')]
+        temperatureMappings[n2k.fields.source]
       if (temperatureMapping) {
         if (temperatureMapping.pathWithIndex) {
           return temperatureMapping.pathWithIndex.replace(
             '<index>',
-            n2k.fields['Instance']
+            n2k.fields.instance
           )
         } else if (temperatureMapping.path) {
           return temperatureMapping.path
         }
       } else {
-        return `generic.temperatures.userDefined${n2k.fields['Source']
+        return `generic.temperatures.userDefined${n2k.fields.source
           .toString()
-          .replace(/\ /g, '_')}.${n2k.fields['Instance']}.temperature`
+          .replace(/\ /g, '_')}.${n2k.fields.instance}.temperature`
       }
     },
     instance: function (n2k) {
-      return chooseField(n2k, 'Temperature Instance', 'Instance') + ''
+      return n2k.fields.instance + ''
     },
-    source: 'Actual Temperature'
+    source: 'actualTemperature'
   }
 ]

--- a/pgns/130313.js
+++ b/pgns/130313.js
@@ -3,16 +3,16 @@ module.exports = [
     node: function (n2k) {
       return (
         'environment.' +
-        (n2k.fields['Source'] === 'Inside'
+        (n2k.fields.source === 'Inside'
           ? 'inside.relativeHumidity'
           : 'outside.humidity')
       )
     },
     filter: function (n2k) {
-      return typeof n2k.fields['Actual Humidity'] !== 'undefined'
+      return typeof n2k.fields.actualHumidity !== 'undefined'
     },
     value: function (n2k) {
-      var ratio100 = Number(n2k.fields['Actual Humidity'])
+      var ratio100 = Number(n2k.fields.actualHumidity)
       return ratio100 / 100
     }
   }

--- a/pgns/130314.js
+++ b/pgns/130314.js
@@ -1,16 +1,15 @@
 const pressureMappings = require('../pressureMappings')
-const { chooseField } = require('../utils.js')
 
 module.exports = [
   {
     node: function (n2k) {
       var pressureMapping =
-        pressureMappings[chooseField(n2k, 'Pressure Source', 'Source')]
+        pressureMappings[n2k.fields.source]
       if (pressureMapping) {
         if (pressureMapping.pathWithIndex) {
           return pressureMapping.pathWithIndex.replace(
             '<index>',
-            n2k.fields['Instance']
+            n2k.fields.instance
           )
         } else if (pressureMapping.path) {
           return pressureMapping.path
@@ -18,8 +17,8 @@ module.exports = [
       }
     },
     instance: function (n2k) {
-      return chooseField(n2k, 'Pressure Instance', 'Instance') + ''
+      return n2k.fields.instance + ''
     },
-    source: 'Pressure'
+    source: 'pressure'
   }
 ]

--- a/pgns/130316.js
+++ b/pgns/130316.js
@@ -1,27 +1,26 @@
 const temperatureMappings = require('../temperatureMappings')
-const { chooseField } = require('../utils.js')
 
 module.exports = [
   {
     node: function (n2k) {
       var temperatureMapping =
-        temperatureMappings[chooseField(n2k, 'Temperature Source', 'Source')]
+        temperatureMappings[n2k.fields.source]
       if (temperatureMapping) {
         if (temperatureMapping.pathWithIndex) {
           return temperatureMapping.pathWithIndex.replace(
             '<index>',
-            n2k.fields['Instance']
+            n2k.fields.instance
           )
         } else if (temperatureMapping.path) {
           return temperatureMapping.path
         }
       } else {
-        return `generic.temperatures.userDefined${n2k.fields['Source']}.${n2k.fields['Instance']}.temperature`
+        return `generic.temperatures.userDefined${n2k.fields.source}.${n2k.fields.instance}.temperature`
       }
     },
     instance: function (n2k) {
-      return chooseField(n2k, 'Temperature Instance', 'Instance') + ''
+      return n2k.fields.instance + ''
     },
-    source: 'Temperature'
+    source: 'temperature'
   }
 ]

--- a/pgns/130577.js
+++ b/pgns/130577.js
@@ -1,34 +1,34 @@
 module.exports = [
   {
-    source: 'COG',
+    source: 'cog',
     node: 'navigation.courseOverGroundTrue',
     filter: function (n2k) {
-      return n2k.fields['COG Reference'] === 'True'
+      return n2k.fields.cogReference === 'True'
     }
   },
   {
-    source: 'SOG',
+    source: 'sog',
     node: 'navigation.speedOverGround',
     filter: function (n2k) {
-      return n2k.fields['SOG']
+      return n2k.fields.sog
     }
   },
   {
     node: 'environment.current',
     filter: function (n2k) {
-      return n2k.fields['Drift'] && n2k.fields['Set']
+      return n2k.fields.drift && n2k.fields.set
     },
     value: function (n2k) {
-      if (n2k.fields['COG Reference'] === 'True') {
+      if (n2k.fields.cogReference === 'True') {
         return {
-          setTrue: Number(n2k.fields.Set),
-          drift: Number(n2k.fields['Drift'])
+          setTrue: Number(n2k.fields.set),
+          drift: Number(n2k.fields.drift)
         }
-      } else if (n2k.fields['Set Reference'] === 'Magnetic') {
+      } else if (n2k.fields.setReference === 'Magnetic') {
         // speculative, I don't have a real world sample showing 'Magnetic'
         return {
-          setTrue: Number(n2k.fields.Set),
-          drift: Number(n2k.fields['Drift'])
+          setTrue: Number(n2k.fields.set),
+          drift: Number(n2k.fields.drift)
         }
       }
     }

--- a/pgns/130842.js
+++ b/pgns/130842.js
@@ -7,57 +7,57 @@ module.exports = [
     node: '',
     value: function (n2k) {
       return {
-        name: n2k.fields.Name
+        name: n2k.fields.name
       }
     },
     filter: function (n2k) {
-      return n2k.fields['Name']
+      return n2k.fields.name
     }
   },
   {
     node: 'design.length',
     value: function (n2k) {
-      return { overall: Number(n2k.fields.Length) }
+      return { overall: Number(n2k.fields.length) }
     },
     filter: function (n2k) {
-      return n2k.fields['Length']
+      return n2k.fields.length
     }
   },
   {
     node: 'design.aisShipType',
     value: function (n2k) {
-      return getShipType(n2k.fields['Type of ship'])
+      return getShipType(n2k.fields.typeOfShip)
     },
     filter: function (n2k) {
-      return n2k.fields['Type of ship']
+      return n2k.fields.typeOfShip
     }
   },
   {
     node: 'design.beam',
-    source: 'Beam',
+    source: 'beam',
     filter: function (n2k) {
-      return n2k.fields['Beam']
+      return n2k.fields.beam
     }
   },
   {
     node: 'sensors.ais.fromBow',
-    source: 'Position reference from Bow'
+    source: 'positionReferenceFromBow'
   },
   {
     node: 'sensors.ais.fromCenter',
     value: getFromStarboard,
     filter: function (n2k) {
       return (
-        n2k.fields['Position reference from Starboard'] && n2k.fields['Beam']
+        n2k.fields.positionReferenceFromStarboard && n2k.fields.beam
       )
     }
   },
   {
     node: '',
-    filter: n2k => n2k.fields['User ID'],
+    filter: n2k => n2k.fields.userId,
     value: function (n2k) {
       return {
-        mmsi: n2k.fields['User ID'].toString()
+        mmsi: n2k.fields.userId.toString()
       }
     }
   },

--- a/pgns/acPower.js
+++ b/pgns/acPower.js
@@ -1,18 +1,18 @@
 module.exports = phase => {
   function prefix (n2k) {
-    return `electrical.ac.${n2k.src}.${n2k.fields['Connection Number']}.${phase}`
+    return `electrical.ac.${n2k.src}.${n2k.fields.connectionNumber}.${phase}`
   }
 
   return [
     {
       node: n2k => prefix(n2k) + '.power',
-      value: n2k => n2k.fields['Power'],
-      filter: n2k => typeof n2k.fields['Power'] !== 'undefined'
+      value: n2k => n2k.fields.power,
+      filter: n2k => typeof n2k.fields.power !== 'undefined'
     },
     {
       node: n2k => prefix(n2k) + '.current',
-      value: n2k => n2k.fields['AC RMS Current'],
-      filter: n2k => typeof n2k.fields['AC RMS Current'] !== 'string'
+      value: n2k => n2k.fields.acRmsCurrent,
+      filter: n2k => typeof n2k.fields.acRmsCurrent !== 'string'
     }
   ]
 }

--- a/raymarine/126720.js
+++ b/raymarine/126720.js
@@ -7,18 +7,18 @@ module.exports = [
     filter: function (n2k) {
       return (
         n2k.description === 'Seatalk1: Display Brightness' &&
-        n2k.fields['Manufacturer Code'] === 'Raymarine' &&
-        n2k.fields['Group'] !== undefined
+        n2k.fields.manufacturerCode === 'Raymarine' &&
+        n2k.fields.group !== undefined
       )
     },
     node: n2k => {
       return `electrical.displays.raymarine.${camelCase(
-        n2k.fields['Group']
+        n2k.fields.group
       )}.brightness`
     },
     allowNull: true,
     value: n2k => {
-      let val = n2k.fields['Brightness']
+      let val = n2k.fields.brightness
       return val !== undefined ? val / 100.0 : null
     }
   },
@@ -27,18 +27,18 @@ module.exports = [
     filter: function (n2k) {
       return (
         n2k.description === 'Seatalk1: Display Color' &&
-        n2k.fields['Manufacturer Code'] === 'Raymarine' &&
-        n2k.fields['Group'] !== undefined
+        n2k.fields.manufacturerCode === 'Raymarine' &&
+        n2k.fields.group !== undefined
       )
     },
     node: n2k => {
       return `electrical.displays.raymarine.${camelCase(
-        n2k.fields['Group']
+        n2k.fields.group
       )}.color`
     },
     allowNull: true,
     value: n2k => {
-      return camelCase(n2k.fields['Color'])
+      return camelCase(n2k.fields.color)
     }
   },
   {
@@ -46,15 +46,15 @@ module.exports = [
     filter: function (n2k) {
       return (
         n2k.description === 'Seatalk1: Pilot Mode' &&
-        n2k.fields['Manufacturer Code'] === 'Raymarine' &&
-        typeof n2k.fields['Pilot Mode'] !== undefined &&
-        typeof n2k.fields['Sub Mode'] !== undefined
+        n2k.fields.manufacturerCode === 'Raymarine' &&
+        typeof n2k.fields.pilotMode !== undefined &&
+        typeof n2k.fields.subMode !== undefined
       )
     },
     node: 'steering.autopilot.state',
     value: function (n2k) {
-      var mode = n2k.fields['Pilot Mode']
-      var subMode = Number(n2k.fields['Sub Mode'])
+      var mode = n2k.fields.pilotMode
+      var subMode = Number(n2k.fields.subMode)
       if (
         (mode == 0 || mode == 'Standby' || mode == 68 || mode == 72) &&
         subMode == 0

--- a/raymarine/65288.js
+++ b/raymarine/65288.js
@@ -2,13 +2,13 @@ module.exports = [
   {
     filter: function (n2k) {
       return (
-        n2k.fields['Manufacturer Code'] === 'Raymarine' &&
-        typeof n2k.fields['Alarm Group'] !== 'undefined' &&
-        typeof n2k.fields['Alarm Status'] !== 'undefined'
+        n2k.fields.manufacturerCode === 'Raymarine' &&
+        typeof n2k.fields.alarmGroup !== 'undefined' &&
+        typeof n2k.fields.alarmStatus !== 'undefined'
       )
     },
     node: function (n2k) {
-      var alarmName = n2k.fields['Alarm ID']
+      var alarmName = n2k.fields.alarmId
 
       if (typeof alarmName === 'string') {
         alarmName = alarmName.replace(/ /g, '')
@@ -17,13 +17,13 @@ module.exports = [
       }
 
       var path =
-        n2k.fields['Alarm Group'].toLowerCase().replace(/ /g, '') +
+        n2k.fields.alarmGroup.toLowerCase().replace(/ /g, '') +
         '.' +
         alarmName
       return 'notifications.' + path
     },
     value: function (n2k) {
-      var state = n2k.fields['Alarm Status']
+      var state = n2k.fields.alarmStatus
 
       var method = ['visual']
 
@@ -37,7 +37,7 @@ module.exports = [
         state = 'alarm'
       }
 
-      var alarmName = n2k.fields['Alarm ID']
+      var alarmName = n2k.fields.alarmId
 
       if (typeof alarmName !== 'string') {
         alarmName = `Unknown Seatalk Alarm ${alarmName}`

--- a/raymarine/65345.js
+++ b/raymarine/65345.js
@@ -2,7 +2,7 @@ module.exports = [
   {
     node: 'steering.autopilot.target.windAngleApparent',
     value: function (n2k) {
-      var angle = Number(n2k.fields['Wind Datum'])
+      var angle = Number(n2k.fields.windDatum)
       if (angle > Math.PI) angle = angle - Math.PI * 2
       return angle
     }

--- a/raymarine/65359.js
+++ b/raymarine/65359.js
@@ -5,19 +5,19 @@ module.exports = [
     filter: function (n2k) {
       return (
         n2k.description === 'Seatalk: Pilot Heading' &&
-        typeof n2k.fields['Heading True'] !== 'undefined'
+        typeof n2k.fields.headingTrue !== 'undefined'
       )
     },
-    source: 'Heading True'
+    source: 'headingTrue'
   },
   {
     node: 'navigation.headingMagnetic',
     filter: function (n2k) {
       return (
         n2k.description === 'Seatalk: Pilot Heading' &&
-        typeof n2k.fields['Heading Magnetic'] !== 'undefined'
+        typeof n2k.fields.headingMagnetic !== 'undefined'
       )
     },
-    source: 'Heading Magnetic'
+    source: 'headingMagnetic'
   }
 ]

--- a/raymarine/65360.js
+++ b/raymarine/65360.js
@@ -2,15 +2,15 @@ module.exports = [
   {
     node: 'steering.autopilot.target.headingTrue',
     filter: function (n2k) {
-      return n2k.fields['Target Heading True']
+      return n2k.fields.targetHeadingTrue
     },
-    source: 'Target Heading True'
+    source: 'targetHeadingTrue'
   },
   {
     node: 'steering.autopilot.target.headingMagnetic',
     filter: function (n2k) {
-      return n2k.fields['Target Heading Magnetic']
+      return n2k.fields.targetHeadingMagnetic
     },
-    source: 'Target Heading Magnetic'
+    source: 'targetHeadingMagnetic'
   }
 ]

--- a/raymarine/65379.js
+++ b/raymarine/65379.js
@@ -2,7 +2,7 @@ module.exports = [
   {
     node: 'steering.autopilot.state',
     value: function (n2k) {
-      var mode = n2k.fields['Pilot Mode']
+      var mode = n2k.fields.pilotMode
       if (typeof mode === 'string') {
         if (mode === 'Standby') {
           return 'standby'
@@ -18,8 +18,8 @@ module.exports = [
           return 'route'
         }
       } else {
-        mode = Number(n2k.fields['Pilot Mode'])
-        var subMode = Number(n2k.fields['Sub Mode'])
+        mode = Number(n2k.fields.pilotMode)
+        var subMode = Number(n2k.fields.subMode)
         if (mode == 0 && subMode == 0) return 'standby'
         else if (mode == 0 && subMode == 1) return 'wind'
         else if ((mode == 128 || mode == 129) && subMode == 1) return 'route'

--- a/simrad/130845.js
+++ b/simrad/130845.js
@@ -5,44 +5,44 @@ module.exports = [
   {
     filter: function (n2k) {
       return (
-        n2k.fields['Manufacturer Code'] === 'Simrad' &&
-          n2k.fields['Display Group'] !== 'undefined' &&
-          n2k.fields['Key'] === 'Backlight level'
+        n2k.fields.manufacturerCode === 'Simrad' &&
+          n2k.fields.displayGroup !== 'undefined' &&
+          n2k.fields.key === 'Backlight level'
       )
     },
-    node: (n2k) => { return `electrical.displays.navico.${camelCase(n2k.fields['Display Group'])}.brightness` },
+    node: (n2k) => { return `electrical.displays.navico.${camelCase(n2k.fields.displayGroup)}.brightness` },
     allowNull: true,
     value: (n2k) => {
-      let val = n2k.fields['Value']
+      let val = n2k.fields.value
       return val !== 'undefined' ? val / 100.0 : null
     }
   },
   {
     filter: function (n2k) {
       return (
-        n2k.fields['Manufacturer Code'] === 'Simrad' &&
-          n2k.fields['Display Group'] !== 'undefined' &&
-          n2k.fields['Key'] === 'Night mode'
+        n2k.fields.manufacturerCode === 'Simrad' &&
+          n2k.fields.displayGroup !== 'undefined' &&
+          n2k.fields.key === 'Night mode'
       )
     },
-    node: (n2k) => { return `electrical.displays.navico.${camelCase(n2k.fields['Display Group'])}.nightMode.state` },
+    node: (n2k) => { return `electrical.displays.navico.${camelCase(n2k.fields.displayGroup)}.nightMode.state` },
     allowNull: true,
     value: (n2k) => {
-      return n2k.fields['Value'] === 4 ? 1 : 0
+      return n2k.fields.value === 4 ? 1 : 0
     }
   },
   {
     filter: function (n2k) {
       return (
-        n2k.fields['Manufacturer Code'] === 'Simrad' &&
-          n2k.fields['Display Group'] !== 'undefined' &&
-          n2k.fields['Key'] === 'Night mode color'
+        n2k.fields.manufacturerCode === 'Simrad' &&
+          n2k.fields.displayGroup !== 'undefined' &&
+          n2k.fields.key === 'Night mode color'
       )
     },
-    node: (n2k) => { return `electrical.displays.navico.${camelCase(n2k.fields['Display Group'])}.nightModeColor` },
+    node: (n2k) => { return `electrical.displays.navico.${camelCase(n2k.fields.displayGroup)}.nightModeColor` },
     allowNull: true,
     value: (n2k) => {
-      let val = nightModeColorMapping[n2k.fields['Value']]
+      let val = nightModeColorMapping[n2k.fields.value]
       return val ? val : 'unknown'
     }
   },

--- a/test/126983_alert.js
+++ b/test/126983_alert.js
@@ -58,7 +58,7 @@ describe('126983 Alert', function () {
       tree.notifications.nmea.warning.navigational[20][23480].value
     ).to.deep.include(value)
 
-    var delta = mapper.toDelta(msg)
+    var delta = mapper.testToDelta(msg)
     delta.updates.length.should.equal(1)
   })
 
@@ -79,7 +79,7 @@ describe('126983 Alert', function () {
       tree.notifications.nmea.warning.navigational[20][23480].value
     ).to.deep.include(value)
 
-    var delta = mapper.toDelta(msg)
+    var delta = mapper.testToDelta(msg)
     delta.updates.length.should.equal(1)
   })
 
@@ -99,7 +99,7 @@ describe('126983 Alert', function () {
       tree.notifications.nmea.warning.navigational[20][23480].value
     ).to.deep.include(value)
 
-    var delta = mapper.toDelta(msg)
+    var delta = mapper.testToDelta(msg)
     delta.updates.length.should.equal(1)
   })
 })

--- a/test/126992_time.js
+++ b/test/126992_time.js
@@ -1,6 +1,7 @@
 var chai = require('chai')
 chai.Should()
 chai.use(require('chai-things'))
+chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('126992 system time', function () {
   it('complete sentence converts', function () {

--- a/test/127488_engine_boost.js
+++ b/test/127488_engine_boost.js
@@ -10,6 +10,7 @@ describe('127488 engine boost Port', function () {
         '{"timestamp":"2015-01-15-16:16:56.749Z","prio":"2","src":"17","dst":"255","pgn":"127488","description":"Engine Parameters, Rapid Update","fields":{"Instance":"Single Engine or Dual Engine Port","Speed":3190, "Boost Pressure": 393000}}'
       )
     )
+    console.log(tree)
     tree.should.have.nested.property('propulsion.port.boostPressure')
     tree.should.have.nested.property(
       'propulsion.port.boostPressure.value',

--- a/test/127506_dc_detailed_status.js
+++ b/test/127506_dc_detailed_status.js
@@ -9,7 +9,7 @@ function generatePGNs (json) {
 describe('127506 dc detailed status', function () {
   it('complete sentence converts', function () {
     generatePGNs(
-      '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"DC Instance":1,"State of Charge":60,"State of Health":99,"Time Remaining": "00:30:00", "Ripple Voltage": 10.9, "SID":0}}'
+      '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"Instance":1,"State of Charge":60,"State of Health":99,"Time Remaining": "00:30:00", "Ripple Voltage": 10.9, "SID":0}}'
     ).forEach(pgn => {
       var tree = require('./testMapper').toNested(JSON.parse(pgn))
       tree.should.have.nested.property(
@@ -30,7 +30,7 @@ describe('127506 dc detailed status', function () {
   })
   it('null timeRemaining converts', function () {
     generatePGNs(
-      '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"DC Instance":1,"SID":0}}'
+      '{"timestamp":"2016-08-22T16:02:55.272Z","prio":6,"src":17,"dst":255,"pgn":127506,"description":"DC Detailed Status","fields":{"instance":1,"SID":0}}'
     ).forEach(pgn => {
       var delta = require('./testMapper').toDelta(JSON.parse(pgn))
       tree = require('./testMapper').toNested(JSON.parse(pgn))

--- a/test/129038_ais_class_a.js
+++ b/test/129038_ais_class_a.js
@@ -32,7 +32,7 @@ describe('129038 Class A Update', function () {
     delete tree.sensors.ais
 
     tree.should.be.validSignalKVesselIgnoringIdentity
-    var delta = mapper.toDelta(msg)
+    var delta = mapper.testToDelta(msg)
     delta.updates.length.should.equal(1)
     delta.context.should.equal('vessels.urn:mrn:imo:mmsi:230982000')
     assertSensorClass(delta, 'A')
@@ -48,7 +48,7 @@ describe('129038 Class A Update', function () {
       'navigation.specialManeuver.value',
       'engaged'
     )
-    var delta = mapper.toDelta(msg)
+    var delta = mapper.testToDelta(msg)
     delta.updates.length.should.equal(1)
     delta.context.should.equal('vessels.urn:mrn:imo:mmsi:230982000')
   })
@@ -83,7 +83,7 @@ describe('129038 Class A Update', function () {
       description: 'AIS Class A Position Report',
       timestamp: '2022-05-09T13:38:38.917Z'
     }
-    const deltaType = typeof mapper.toDelta(msg, {})
+    const deltaType = typeof mapper.testToDelta(msg, {})
     deltaType.should.equal('undefined')
   })
 })

--- a/test/129039_ais_class_b.js
+++ b/test/129039_ais_class_b.js
@@ -29,7 +29,7 @@ describe('129039 Class B Update', function () {
     delete tree.sensors.ais
 
     tree.should.be.validSignalKVesselIgnoringIdentity
-    var delta = mapper.toDelta(msg)
+    var delta = mapper.testToDelta(msg)
     delta.updates.length.should.equal(1)
     assert.equal(delta.context, 'vessels.urn:mrn:imo:mmsi:230035780')
     assertSensorClass(delta, 'B')
@@ -54,7 +54,7 @@ describe('129039 Class B Update', function () {
     delete tree.sensors.ais
 
     tree.should.be.validSignalKVesselIgnoringIdentity
-    var delta = mapper.toDelta(msg)
+    var delta = mapper.testToDelta(msg)
     delta.updates.length.should.equal(1)
     delta.context.should.equal('vessels.urn:mrn:imo:mmsi:235087238')
     assertSensorClass(delta, 'B')

--- a/test/129040_class_b_extended.js
+++ b/test/129040_class_b_extended.js
@@ -11,7 +11,7 @@ describe('129040 AIS Class B Extended Position Repeat', function () {
     var msg = JSON.parse(
       '{"timestamp":"2014-08-15-15:01:01.881Z","prio":"6","src":"43","dst":"255","pgn":"129040","description":"AIS Class B Extended Position Report","fields":{"Message ID":"5","Repeat indicator":"Initial","User ID":"230939100","Name":"RESCUE RAUTAUOMA","Type of ship":"SAR","Length":16.0,"Beam":4.0,"Position reference from Starboard":2.0,"Position reference from Bow":9.0,"ETA Date":"2014.11.30", "ETA Time": "25:00:00","Draft":"1.00","AIS version indicator":"ITU-R M.1371-1","GNSS type":"GPS","DTE":"available","Reserved":"0","AIS Transceiver information":"Channel B VDL reception", "True Heading": 1.58,"Longitude":25.2026083,"Latitude":60.2176150,"COG":1.54,"SOG":2.26}}'
     )
-    var delta = mapper.toDelta(msg)
+    var delta = mapper.testToDelta(msg)
     delta.updates.length.should.equal(1)
     delta.context.should.equal('vessels.urn:mrn:imo:mmsi:230939100')
     delta.updates[0].values[0].path.should.equal('')

--- a/test/129041_aton_report.js
+++ b/test/129041_aton_report.js
@@ -10,11 +10,11 @@ describe('129041 AIS Aids to Navigation (AtoN) Report', function () {
     var msg = JSON.parse(
       '{"timestamp":"2017-03-14T19:02:40.451Z","prio":4,"src":43,"dst":255,"pgn":129041,"description":"AIS Aids to Navigation (AtoN) Report","fields":{"Message ID":21,"Repeat Indicator":"Initial","User ID":993672315,"Longitude":-76.3847132,"Latitude":38.9938400,"Position Accuracy":"High","AIS RAIM Flag":"not in use","Time Stamp":"Manual input mode","AtoN Type":"Fixed beacon: port hand","Off Position Indicator":"No","Virtual AtoN Flag":"Yes","Assigned Mode Flag":"Autonomous and continuous","AIS Spare":"0","Position Fixing Device Type":"Surveyed","AtoN Status":"0","AIS Transceiver information":"Channel B VDL reception","AtoN Name":"SW                  @"}}'
     )
-    var delta = mapper.toDelta(msg)
+    var delta = mapper.testToDelta(msg)
     delta.updates.length.should.equal(1)
     delta.context.should.equal('atons.urn:mrn:imo:mmsi:993672315')
     delta.updates[0].values[0].path.should.equal('')
-    delta.updates[0].values[0].value.name.should.equal('SW                  @')
+    delta.updates[0].values[0].value.name.should.equal('SW')
     var tree = mapper.toNested(msg)
     tree.should.have.nested.property('atonType.value.name', 'Beacon, Port Hand')
     tree.should.have.nested.property('atonType.value.id', 13)

--- a/test/129284_navigation_data.js
+++ b/test/129284_navigation_data.js
@@ -40,7 +40,7 @@ describe('129284 Navigation Data', function () {
       31360.412
     )
     tree.should.be.validSignalKVesselIgnoringIdentity
-    var delta = mapper.toDelta(msg)
+    var delta = mapper.testToDelta(msg)
     delta.updates.length.should.equal(1)
   })
 })

--- a/test/129285_route_info.js
+++ b/test/129285_route_info.js
@@ -11,7 +11,6 @@ describe('129285 Route Information', function () {
       '{"timestamp":"2017-04-15T21:50:57.780Z","prio":6,"pgn":129285,"src":3,"dst":255,"fields":{"Start RPS#":12,"nItems":3,"Database ID":0,"Route ID":0,"Navigation direction in route":3,"Supplementary Route/WP data available":1,"Route Name":"Route","list":[{"WP ID":12,"WP Name":"Waypoint 240","WP Latitude":39.1525868,"WP Longitude":-76.1811988},{"WP ID":13,"WP Name":"Waypoint 241","WP Latitude":39.1568741,"WP Longitude":-76.1834715},{"WP ID":14,"WP Name":"Waypoint 242","WP Latitude":39.159168,"WP Longitude":-76.182178}]},"description":"Navigation - Route/WP Information"}'
     )
     var tree = mapper.toNested(msg)
-    console.log(JSON.stringify(tree))
     tree.should.have.nested.property(
       'navigation.currentRoute.name.value',
       'Route'

--- a/test/129793_ais_base_station_data.js
+++ b/test/129793_ais_base_station_data.js
@@ -32,7 +32,7 @@ describe('129793 AIS UTC and Date Report (Base Station)', function () {
         Spare: '0'
       }
     }
-    const delta = mapper.toDelta(msg)
+    const delta = mapper.testToDelta(msg)
     delta.updates.length.should.equal(1)
     const values = delta.updates[0].values
     values.length.should.equal(3)

--- a/test/129794_ais_class_a_static_data.js
+++ b/test/129794_ais_class_a_static_data.js
@@ -45,7 +45,7 @@ describe('129794 AIS Class A Static and Voyage Related Data', function () {
     var msg = JSON.parse(
       '{"timestamp":"2017-03-13T18:30:56.945Z","prio":6,"src":43,"dst":255,"pgn":129794,"description":"AIS Class A Static and Voyage Related Data","fields":{"Message ID":5,"Repeat indicator":"Initial","User ID":356307000,"IMO number":9683362,"Callsign":"3FJJ4","Name":"SILVER GWEN","Type of ship":"Tanker (hazard cat Z)","Length":183.0,"Beam":32.0,"Position reference from Starboard":8.0,"Position reference from Bow":147.0,"ETA Date":"2018.03.11", "ETA Time": "07:00:00","Draft":10.60,"Destination":"USA (BALTIMORE)","AIS version indicator":"ITU-R M.1371-3","GNSS type":"GPS","DTE":"available","AIS Transceiver information":"Channel A VDL reception"}}'
     )
-    var delta = mapper.toDelta(msg)
+    var delta = mapper.testToDelta(msg)
     delta.updates.length.should.equal(1)
     delta.context.should.equal('vessels.urn:mrn:imo:mmsi:356307000')
     assertSensorClass(delta, 'A')
@@ -102,45 +102,5 @@ describe('129794 AIS Class A Static and Voyage Related Data', function () {
     delete tree.design.aisShipType
     //TODO enable when sensors.ais.class is in the schema
     //tree.should.be.validSignalKVesselIgnoringIdentity
-  })
-
-  it('Empty destination converts to empty string', () => {
-    const msg = {
-      prio: 6,
-      pgn: 129794,
-      dst: 255,
-      src: 43,
-      timestamp: '2014-08-15T19:05:41.030Z',
-      input: [
-        '2014-08-15T19:05:41.030Z,6,129794,43,255,75,05,b0,7f,79,10,00,00,00,00,45,53,59,32,31,31,31,50,56,4c,2d,31,31,31,20,56,41,50,50,45,52,20,20,20,20,20,20,37,7c,01,3c,00,14,00,b4,00,14,40,00,00,00,00,00,00,40,40,40,40,40,40,40,40,40,40,40,40,40,40,40,40,40,40,40,40,00,e1'
-      ],
-      fields: {
-        'Message ID': 5,
-        'Repeat indicator': 'Initial',
-        'User ID': 276398000,
-        'IMO number': 0,
-        Callsign: 'ESY2111',
-        Name: 'PVL-111 VAPPER',
-        'Type of ship': 'Law enforcement',
-        Length: 38,
-        Beam: 6,
-        'Position reference from Starboard': 2,
-        'Position reference from Bow': 18,
-        'ETA Date': '2014.11.30',
-        'ETA Time': '00:00:00',
-        Draft: 0,
-        Destination: '',
-        'AIS version indicator': 'ITU-R M.1371-1',
-        'GNSS type': 'undefined',
-        DTE: 'available',
-        Reserved1: '0',
-        'AIS Transceiver information': 'Channel B VDL reception'
-      },
-      description: 'AIS Class A Static and Voyage Related Data'
-    }
-    const delta = mapper.toDelta(msg)
-    delta.updates[0].values
-      .find(pv => pv.path === 'navigation.destination.commonName')
-      .value.should.equal('')
   })
 })

--- a/test/129798_sar.js
+++ b/test/129798_sar.js
@@ -11,7 +11,7 @@ describe('129798 AIS SAR Aircraft Position Report', function () {
     var msg = JSON.parse(
       '{"prio":4,"pgn":129798,"dst":255,"src":43,"timestamp":"2017-07-20T16:50:11.352Z", "fields":{"Message ID":9,"Repeat indicator":"Initial","User ID":338254261,"Longitude":-75.8338099,"Latitude":39.6475617,"Position Accuracy":"High","RAIM":"in use","Time Stamp":"10","COG":2.227,"SOG":694.4,"Communication State":"33188","AIS Transceiver information":"Channel A VDL reception"},"description":"AIS SAR Aircraft Position Report"}'
     )
-    var delta = mapper.toDelta(msg)
+    var delta = mapper.testToDelta(msg)
     delta.updates.length.should.equal(1)
     delta.context.should.equal('sar.urn:mrn:imo:mmsi:338254261')
     assertSensorClass(delta, 'SAR')

--- a/test/129809_ais_class_b_static_data.js
+++ b/test/129809_ais_class_b_static_data.js
@@ -10,7 +10,7 @@ describe('129809 Class B static data', function () {
     var msg = JSON.parse(
       '{"timestamp":"2014-08-15-15:00:04.655","prio":"6","src":"43","dst":"255","pgn":"129809","description":"AIS Class B static data (msg 24 Part A)","fields":{"Message ID":"24","Repeat indicator":"Initial","User ID":"230044160","Name":"LAGUNA"}}'
     )
-    var delta = mapper.toDelta(msg)
+    var delta = mapper.testToDelta(msg)
     delta.updates.length.should.equal(1)
     delta.context.should.equal('vessels.urn:mrn:imo:mmsi:230044160')
     delta.updates[0].values

--- a/test/130310-2.json
+++ b/test/130310-2.json
@@ -29,12 +29,12 @@
     "description": "Environmental Parameters",
     "fields": {
       "SID": "154",
-      "Outside Ambient Air Temperature": "7.76",
-      "Atmospheric Pressure": "1018"
+      "Outside Ambient Air Temperature": 7.76,
+      "Atmospheric Pressure": 101800
     },
     "testExpectConvertedValues": {
       "environment.outside.temperature": 7.76,
-      "environment.outside.pressure": 1018
+      "environment.outside.pressure": 101800
     }
   },
   "130310-water-temperature": {

--- a/test/130314_pressure_new.js
+++ b/test/130314_pressure_new.js
@@ -16,7 +16,7 @@ describe('Pressure: ', function () {
     it(`Converts ${testCaseName}`, () => {
       const testCase = testCases[testCaseName]
 
-      var delta = n2kMapper.toDelta(testCase)
+      var delta = n2kMapper.testToDelta(testCase)
       delta.context = 'vessels.urn:mrn:imo:mmsi:230099999'
       delta.updates[0].source.label = 'aLabel'
       full.addDelta(delta)

--- a/test/13031_temperature.js
+++ b/test/13031_temperature.js
@@ -16,7 +16,7 @@ describe('Temperature: ', function () {
     it(`Converts ${testCaseName}`, () => {
       const testCase = testCases[testCaseName]
 
-      var delta = n2kMapper.toDelta(testCase)
+      var delta = n2kMapper.testToDelta(testCase)
       delta.context = 'vessels.urn:mrn:imo:mmsi:230099999'
       delta.updates[0].source.label = 'aLabel'
       full.addDelta(delta)

--- a/test/130842_simnet_class_b_extended.js
+++ b/test/130842_simnet_class_b_extended.js
@@ -10,7 +10,7 @@ describe('130842 Simnet AIS Class B static data', function () {
     var msg = JSON.parse(
       '{"timestamp":"2017-03-13T18:32:13.343Z","prio":6,"src":43,"dst":255,"pgn":130842,"description":"Simnet: AIS Class B static data (msg 24 Part A)","fields":{"Manufacturer Code":"Simrad","Industry Code":"Marine Industry","Message ID":"Msg 24 Part A","Repeat indicator":"Second retransmission","E":24,"User ID":338184313,"Name":"WILHELM"}}'
     )
-    var delta = mapper.toDelta(msg)
+    var delta = mapper.testToDelta(msg)
     delta.updates.length.should.equal(1)
     delta.context.should.equal('vessels.urn:mrn:imo:mmsi:338184313')
     delta.updates[0].values[0].path.should.equal('')
@@ -23,7 +23,7 @@ describe('130842 Simnet AIS Class B static data', function () {
     var msg = JSON.parse(
       '{"timestamp":"2017-03-13T18:26:24.199Z","prio":6,"src":43,"dst":255,"pgn":130842,"description":"Simnet: AIS Class B static data (msg 24 Part B)","fields":{"Manufacturer Code":"Simrad","Industry Code":"Marine Industry","Message ID":"Msg 24 Part B","Repeat indicator":"Second retransmission","E":24,"User ID":338184313,"Type of ship":"Sailing","Vendor ID":"SMTD*:0","Callsign":"","Length":9.0,"Beam":4.0,"Position reference from Starboard":2.0,"Position reference from Bow":6.0,"Mothership User ID":0,"":0,"Spare":48}}'
     )
-    var delta = mapper.toDelta(msg)
+    var delta = mapper.testToDelta(msg)
     delta.updates.length.should.equal(1)
     delta.context.should.equal('vessels.urn:mrn:imo:mmsi:338184313')
     var tree = mapper.toNested(msg)

--- a/test/errorhandling.js
+++ b/test/errorhandling.js
@@ -14,6 +14,7 @@ describe('Unknown pgn', function () {
   })
 })
 
+
 describe('No fields in pgn message', function () {
   it('does not throw any errors', function () {
     //  missing User Id
@@ -23,9 +24,12 @@ describe('No fields in pgn message', function () {
       prio: '6',
       src: '43',
       dst: '255',
-      pgn: '129794',
-      description: 'AIS Class A Static and Voyage Related Data'
+      pgn: 128267,
     }
-    mapper.toDelta(msg).updates.length.should.equal(0)
+    
+
+    var delta = mapper.toDelta(msg)
+    assert.equal(delta.updates[0].values.length, 0)
   })
 })
+

--- a/test/maretron.js
+++ b/test/maretron.js
@@ -16,13 +16,13 @@ describe('Maretron AC PGNs work', function () {
     src: 192,
     timestamp: '2019-05-31T11:46:58.594Z',
     fields: {
-      'Unique Number': '76223',
-      'Device Instance Lower': 0,
-      'Device Instance Upper': 1,
-      'Device Function': 130,
+      'uniqueNumber': '76223',
+      'deviceInstanceLower': 0,
+      'deviceInstanceUpper': 1,
+      'deviceFunction': 130,
       Reserved1: '0',
-      'System Instance': 0,
-      'Industry Group': 'Marine',
+      'systemInstance': 0,
+      'industryGroup': 'Marine',
       Reserved2: '1'
     },
     description: 'ISO Address Claim'
@@ -35,13 +35,13 @@ describe('Maretron AC PGNs work', function () {
     src: 193,
     timestamp: '2019-05-31T11:46:58.594Z',
     fields: {
-      'Unique Number': '76223',
-      'Device Instance Lower': 0,
-      'Device Instance Upper': 2,
-      'Device Function': 130,
+      'uniqueNumber': '76223',
+      'deviceInstanceLower': 0,
+      'deviceInstanceUpper': 2,
+      'deviceFunction': 130,
       Reserved1: '0',
-      'System Instance': 0,
-      'Industry Group': 'Marine',
+      'systemInstance': 0,
+      'industryGroup': 'Marine',
       Reserved2: '1'
     },
     description: 'ISO Address Claim'
@@ -54,13 +54,13 @@ describe('Maretron AC PGNs work', function () {
     src: 194,
     timestamp: '2019-05-31T11:46:58.594Z',
     fields: {
-      'Unique Number': '76223',
-      'Device Instance Lower': 0,
-      'Device Instance Upper': 3,
-      'Device Function': 130,
+      'uniqueNumber': '76223',
+      'deviceInstanceLower': 0,
+      'deviceInstanceUpper': 3,
+      'deviceFunction': 130,
       Reserved1: '0',
-      'System Instance': 0,
-      'Industry Group': 'Marine',
+      'systemInstance': 0,
+      'industryGroup': 'Marine',
       Reserved2: '1'
     },
     description: 'ISO Address Claim'
@@ -120,9 +120,9 @@ describe('Maretron AC PGNs work', function () {
     direction: 'R',
     time: '18:58:11.940',
     fields: {
-      'Reactive Power': 37888,
-      'Power Factor': 30517,
-      'Power Factor Lagging': 'Leading'
+      'reactivePower': 37888,
+      'powerFactor': 30517,
+      'powerFactorLagging': 'Leading'
     },
     description: 'Utility Phase B AC Reactive Power',
     timestamp: '2020-03-28T18:58:12.480Z'

--- a/test/meta.js
+++ b/test/meta.js
@@ -26,16 +26,16 @@ describe('Meta data works', function () {
       src: 12,
       timestamp: '2019-05-31T11:46:58.594Z',
       fields: {
-        'Unique Number': 76223,
-        'Manufacturer Code': 'Fusion Electronics',
-        'Device Instance Lower': 0,
-        'Device Instance Upper': 0,
-        'Device Function': 130,
+        'uniqueNumber': 76223,
+        'manufacturerCode': 'Fusion Electronics',
+        'deviceInstanceLower': 0,
+        'deviceInstanceUpper': 0,
+        'deviceFunction': 130,
         Spare: 0,
-        'Device Class': 'Entertainment',
-        'System Instance': 0,
-        'Industry Group': 'Marine',
-        'Arbitrary address capable': 1
+        'deviceClass': 'Entertainment',
+        'systemInstance': 0,
+        'industryGroup': 'Marine',
+        'arbitraryAddressCapable': 1
       },
       description: 'ISO Address Claim'
     })
@@ -56,9 +56,9 @@ describe('Meta data works', function () {
       src: 12,
       timestamp: '2019-05-31T11:56:11.266Z',
       fields: {
-        'Installation Description #1': 'UD-650',
-        'Installation Description #2': 'FUSION',
-        'Installation Description #3': 'Fusion Electronics Ltd'
+        'installationDescription1': 'UD-650',
+        'installationDescription2': 'FUSION',
+        'installationDescription3': 'Fusion Electronics Ltd'
       },
       description: 'Configuration Information'
     })
@@ -84,14 +84,14 @@ describe('Meta data works', function () {
       src: 12,
       timestamp: '2019-05-31T11:53:13.922Z',
       fields: {
-        'NMEA 2000 Version': 1301,
-        'Product Code': 3115,
-        'Model ID': 'UD-650',
-        'Software Version Code': '2.0.265',
-        'Model Version': 'FUSION-LINK-1.0',
-        'Model Serial Code': '76223',
-        'Certification Level': 1,
-        'Load Equivalency': 1
+        'nmea2000Version': 1301,
+        'productCode': 3115,
+        'modelId': 'UD-650',
+        'softwareVersionCode': '2.0.265',
+        'modelVersion': 'FUSION-LINK-1.0',
+        'modelSerialCode': '76223',
+        'certificationLevel': 1,
+        'loadEquivalency': 1
       },
       description: 'Product Information'
     })

--- a/test/testMapper.js
+++ b/test/testMapper.js
@@ -4,7 +4,7 @@ const signalkSchema = require('@signalk/signalk-schema')
 const canboatjs = require('@canboat/canboatjs')
 const { FromPgn, pgnToActisenseSerialFormat } = canboatjs
 const Parser = canboatjs.FromPgn
-const parser = new FromPgn()
+const parser = new FromPgn({useCamel: true})
 
 /*
   By default we take the input canboat json and convert to actisense format,
@@ -22,13 +22,24 @@ n2kMapper.toNested = function (n2k, state) {
   }
 }
 
+n2kMapper.testToDelta = function (n2k, state) {
+  var actisense = pgnToActisenseSerialFormat(n2k)
+  var parsed = parser.parseString(actisense)
+  //console.log(JSON.stringify(n2k))
+  //console.log(actisense)
+  //console.log(JSON.stringify(parsed, null, 2))
+  return n2kMapper.toDelta(parsed, state)
+}
+
 n2kMapper.doubleConvertWithCanboat = function (n2k, state) {
   var actisense = pgnToActisenseSerialFormat(n2k)
   var parsed = parser.parseString(actisense)
+  //console.log(parsed)
   parsed.src = n2k.src
   if (n2k.timestamp) {
     parsed.timestamp = n2k.timestamp
   }
+  //console.log(parsed)
   var delta = n2kMapper.toDelta(parsed, state)
   if (!delta.context) {
     delta.context = 'vessels.' + signalkSchema.fakeMmsiId

--- a/utils.js
+++ b/utils.js
@@ -8,7 +8,7 @@ function chooseField (n2k, field1, field2) {
 }
 
 function skEngineId (n2k) {
-  let id = chooseField(n2k, 'Engine Instance', 'Instance')
+  let id = n2k.fields.instance
   if (typeof id === 'number') {
     return id
   } else {
@@ -26,7 +26,7 @@ function skEngineTitle (n2k) {
 }
 
 function acPhase (n2k) {
-  const line = n2k.fields['Line']
+  const line = n2k.fields.line
   if (!line) {
     return 'A'
   } else {


### PR DESCRIPTION
Use the "Id" for fields instead of the "Name".

In canboat/js we will be moving to always keep the "Id" consitent, but allow the Name fields to change.

I also plan to eventually generate TypeScript definitions for PGN data in canboatjs

See https://github.com/canboat/canboat/issues/526