### PR TITLE
fix: convert stateOfHealth from percentage to ratio

### DIFF
--- a/pgns/127506.js
+++ b/pgns/127506.js
@@ -17,7 +17,12 @@ module.exports = [
     }
   },
   {
-    source: 'stateOfHealth',
+    value: function (n2k) {
+      return n2k.fields.stateOfHealth / 100
+    },
+    filter: function (n2k) {
+      return typeof n2k.fields.stateOfHealth !== 'undefined'
+    },
     node: function (n2k) {
       return 'electrical.batteries.' + instance(n2k) + '.capacity.stateOfHealth'
     }

--- a/test/127506_dc_detailed_status.js
+++ b/test/127506_dc_detailed_status.js
@@ -18,7 +18,7 @@ describe('127506 dc detailed status', function () {
       )
       tree.should.have.nested.property(
         'electrical.batteries.1.capacity.stateOfHealth.value',
-        99
+        0.99
       )
       tree.should.have.nested.property(
         'electrical.batteries.1.capacity.timeRemaining.value',
@@ -27,6 +27,38 @@ describe('127506 dc detailed status', function () {
       // tree.should.have.nested.property('electrical.batteries.1.voltage.ripple.value', 10.9);
       tree.should.be.validSignalKVesselIgnoringIdentity
     })
+  })
+  it('stateOfHealth percentage converts to ratio', function () {
+    // Canboat output: stateOfHealth is a percentage (0-100)
+    // SignalK expects: ratio (0-1) per schema definition ("State of Health, 1 = 100%")
+    var canboatInput = {
+      pgn: 127506,
+      prio: 6,
+      src: 224,
+      dst: 255,
+      timestamp: '2026-01-01T01:12:26.703Z',
+      description: 'DC Detailed Status',
+      fields: {
+        sid: 86,
+        instance: 0,
+        dcType: 'Battery',
+        stateOfCharge: 87,
+        stateOfHealth: 88,
+        timeRemaining: null,
+        rippleVoltage: null,
+        remainingCapacity: null
+      },
+      id: 'dcDetailedStatus'
+    }
+    var delta = require('./testMapper').testToDelta(canboatInput)
+    var stateOfHealthValue = delta.updates[0].values.find(
+      v => v.path === 'electrical.batteries.0.capacity.stateOfHealth'
+    )
+    stateOfHealthValue.value.should.equal(0.88)
+    var stateOfChargeValue = delta.updates[0].values.find(
+      v => v.path === 'electrical.batteries.0.capacity.stateOfCharge'
+    )
+    stateOfChargeValue.value.should.equal(0.87)
   })
   it('null timeRemaining converts', function () {
     generatePGNs(


### PR DESCRIPTION
NMEA2000 PGN 127506 sends stateOfHealth as a percentage (0-100), but Signal K expects a ratio (0-1) per the schema definition ("State of Health, 1 = 100%", units: "ratio").

This was already correctly handled for stateOfCharge but missing for stateOfHealth, causing the DataBrowser to display values like "8600%" instead of "86%".

Fixes SignalK/n2k-signalk#303