### PR TITLE
Fix TypeError in requestMetaData when n2kOut is not available

### DIFF
--- a/n2kMapper.js
+++ b/n2kMapper.js
@@ -51,6 +51,12 @@ N2kMapper.prototype.n2kOutIsAvailable = function (listener, event) {
 }
 
 N2kMapper.prototype.requestMetaData = function (dst, pgn) {
+  if (!this.n2kListener) {
+    debug(
+      `n2kOut not available, skipping request for pgn ${pgn} from src ${dst}`
+    )
+    return Promise.resolve()
+  }
   const reqPgn = {
     pgn: 59904,
     dst: dst,


### PR DESCRIPTION
## Summary

- `requestMetaData()` crashes with `TypeError: Cannot read properties of undefined (reading 'emit')` when `this.n2kListener` is not yet initialized
- This happens when a device changes its N2K source address (PGN 60928 with a different CAN name) before `n2kOutIsAvailable()` has been called
- Added a guard to return early if `n2kListener` is not set

## How to reproduce

On a CAN bus with many devices, an address claim conflict can cause a device to change its source address. When this happens before NMEA2000 output is available, `toDelta()` calls `requestMetaData()` which crashes:

```
n2k-signalk: address 254 changed from c0a0aa3d11356802 c0a0aa3e11356801
TypeError: Cannot read properties of undefined (reading 'emit')
    at /node_modules/@signalk/n2k-signalk/dist/n2kMapper.js:55:26
    at new Promise (<anonymous>)
    at N2kMapper.requestMetaData (n2kMapper.js:54:12)
    at N2kMapper.toDelta (n2kMapper.js:104:22)
```

## Fix

Guard `requestMetaData()` to return early (with a resolved promise) when `n2kListener` is undefined, instead of crashing. The metadata request will simply be skipped — once `n2kOutIsAvailable()` is eventually called, `requestAllMeta()` will request metadata for all known sources anyway.

