### PR TITLE
feat: add ETA support for AIS vessel

### DIFF
--- a/pgns/129285.js
+++ b/pgns/129285.js
@@ -3,27 +3,127 @@ const _ = require('lodash')
 
 module.exports = [
   {
-    node: 'navigation.currentRoute.name',
+    node: function (n2k, state) {
+      return (
+        'navigation.course' +
+        state.lastCourseCalculationType +
+        '.activeRoute.name'
+      )
+    },
+    filter: function (n2k, state) {
+      return (
+        typeof state === 'object' &&
+        typeof state.lastCourseCalculationType !== 'undefined'
+      )
+    },
     source: 'routeName'
   },
   {
-    node: 'navigation.currentRoute.waypoints',
-    filter: n2k => {
-      return !_.isUndefined(n2k.fields.list)
+    node: function (n2k, state) {
+      return (
+        'navigation.course' +
+        state.lastCourseCalculationType +
+        '.previousPoint.name'
+      )
     },
-    value: n2k => {
-      var idx = 0
-      return n2k.fields.list.map(wp => {
-        return {
-          name: wp.wpName,
-          position: {
-            value: {
-              latitude: wp.wpLatitude,
-              longitude: wp.wpLongitude
-            }
-          }
-        }
-      })
+    filter: function (n2k, state) {
+      return (
+        typeof state === 'object' &&
+        typeof state.lastCourseCalculationType !== 'undefined' &&
+        !_.isUndefined(n2k.fields.list) &&
+        n2k.fields.list.length > 0
+      )
+    },
+    value: function (n2k) {
+      return n2k.fields.list[0].wpName
+    }
+  },
+  {
+    node: function (n2k, state) {
+      return (
+        'navigation.course' +
+        state.lastCourseCalculationType +
+        '.previousPoint.position'
+      )
+    },
+    filter: function (n2k, state) {
+      return (
+        typeof state === 'object' &&
+        typeof state.lastCourseCalculationType !== 'undefined' &&
+        !_.isUndefined(n2k.fields.list) &&
+        n2k.fields.list.length > 0
+      )
+    },
+    value: function (n2k) {
+      return {
+        latitude: n2k.fields.list[0].wpLatitude,
+        longitude: n2k.fields.list[0].wpLongitude
+      }
+    }
+  },
+  {
+    node: function (n2k, state) {
+      return (
+        'navigation.course' +
+        state.lastCourseCalculationType +
+        '.nextPoint.name'
+      )
+    },
+    filter: function (n2k, state) {
+      return (
+        typeof state === 'object' &&
+        typeof state.lastCourseCalculationType !== 'undefined' &&
+        !_.isUndefined(n2k.fields.list) &&
+        n2k.fields.list.length > 1
+      )
+    },
+    value: function (n2k) {
+      return n2k.fields.list[1].wpName
+    }
+  },
+  {
+    node: function (n2k, state) {
+      return (
+        'navigation.course' +
+        state.lastCourseCalculationType +
+        '.followingPoint.name'
+      )
+    },
+    filter: function (n2k, state) {
+      return (
+        typeof state === 'object' &&
+        typeof state.lastCourseCalculationType !== 'undefined' &&
+        !_.isUndefined(n2k.fields.list) &&
+        n2k.fields.list.length > 2 &&
+        !_.isUndefined(n2k.fields.list[2].wpLatitude) &&
+        !_.isUndefined(n2k.fields.list[2].wpLongitude)
+      )
+    },
+    value: function (n2k) {
+      return n2k.fields.list[2].wpName
+    }
+  },
+  {
+    node: function (n2k, state) {
+      return (
+        'navigation.course' +
+        state.lastCourseCalculationType +
+        '.followingPoint.position'
+      )
+    },
+    filter: function (n2k, state) {
+      return (
+        typeof state === 'object' &&
+        typeof state.lastCourseCalculationType !== 'undefined' &&
+        !_.isUndefined(n2k.fields.list) &&
+        n2k.fields.list.length > 2
+      )
+    },
+    value: function (n2k) {
+      return {
+        latitude: n2k.fields.list[2].wpLatitude,
+        longitude: n2k.fields.list[2].wpLongitude
+      }
     }
   }
 ]

--- a/pgns/129285.js
+++ b/pgns/129285.js
@@ -3,127 +3,27 @@ const _ = require('lodash')
 
 module.exports = [
   {
-    node: function (n2k, state) {
-      return (
-        'navigation.course' +
-        state.lastCourseCalculationType +
-        '.activeRoute.name'
-      )
-    },
-    filter: function (n2k, state) {
-      return (
-        typeof state === 'object' &&
-        typeof state.lastCourseCalculationType !== 'undefined'
-      )
-    },
+    node: 'navigation.currentRoute.name',
     source: 'routeName'
   },
   {
-    node: function (n2k, state) {
-      return (
-        'navigation.course' +
-        state.lastCourseCalculationType +
-        '.previousPoint.name'
-      )
+    node: 'navigation.currentRoute.waypoints',
+    filter: n2k => {
+      return !_.isUndefined(n2k.fields.list)
     },
-    filter: function (n2k, state) {
-      return (
-        typeof state === 'object' &&
-        typeof state.lastCourseCalculationType !== 'undefined' &&
-        !_.isUndefined(n2k.fields.list) &&
-        n2k.fields.list.length > 0
-      )
-    },
-    value: function (n2k) {
-      return n2k.fields.list[0].wpName
-    }
-  },
-  {
-    node: function (n2k, state) {
-      return (
-        'navigation.course' +
-        state.lastCourseCalculationType +
-        '.previousPoint.position'
-      )
-    },
-    filter: function (n2k, state) {
-      return (
-        typeof state === 'object' &&
-        typeof state.lastCourseCalculationType !== 'undefined' &&
-        !_.isUndefined(n2k.fields.list) &&
-        n2k.fields.list.length > 0
-      )
-    },
-    value: function (n2k) {
-      return {
-        latitude: n2k.fields.list[0].wpLatitude,
-        longitude: n2k.fields.list[0].wpLongitude
-      }
-    }
-  },
-  {
-    node: function (n2k, state) {
-      return (
-        'navigation.course' +
-        state.lastCourseCalculationType +
-        '.nextPoint.name'
-      )
-    },
-    filter: function (n2k, state) {
-      return (
-        typeof state === 'object' &&
-        typeof state.lastCourseCalculationType !== 'undefined' &&
-        !_.isUndefined(n2k.fields.list) &&
-        n2k.fields.list.length > 1
-      )
-    },
-    value: function (n2k) {
-      return n2k.fields.list[1].wpName
-    }
-  },
-  {
-    node: function (n2k, state) {
-      return (
-        'navigation.course' +
-        state.lastCourseCalculationType +
-        '.followingPoint.name'
-      )
-    },
-    filter: function (n2k, state) {
-      return (
-        typeof state === 'object' &&
-        typeof state.lastCourseCalculationType !== 'undefined' &&
-        !_.isUndefined(n2k.fields.list) &&
-        n2k.fields.list.length > 2 &&
-        !_.isUndefined(n2k.fields.list[2].wpLatitude) &&
-        !_.isUndefined(n2k.fields.list[2].wpLongitude)
-      )
-    },
-    value: function (n2k) {
-      return n2k.fields.list[2].wpName
-    }
-  },
-  {
-    node: function (n2k, state) {
-      return (
-        'navigation.course' +
-        state.lastCourseCalculationType +
-        '.followingPoint.position'
-      )
-    },
-    filter: function (n2k, state) {
-      return (
-        typeof state === 'object' &&
-        typeof state.lastCourseCalculationType !== 'undefined' &&
-        !_.isUndefined(n2k.fields.list) &&
-        n2k.fields.list.length > 2
-      )
-    },
-    value: function (n2k) {
-      return {
-        latitude: n2k.fields.list[2].wpLatitude,
-        longitude: n2k.fields.list[2].wpLongitude
-      }
+    value: n2k => {
+      var idx = 0
+      return n2k.fields.list.map(wp => {
+        return {
+          name: wp.wpName,
+          position: {
+            value: {
+              latitude: wp.wpLatitude,
+              longitude: wp.wpLongitude
+            }
+          }
+        }
+      })
     }
   }
 ]

--- a/pgns/129794.js
+++ b/pgns/129794.js
@@ -25,7 +25,6 @@ module.exports = [
   {
     node: 'navigation.destination.eta',
     value: function (n2k) {
-      console.debug('etaDate', n2k.fields.etaDate)
       if (typeof n2k.fields.etaDate === 'string') {
         const datePart = n2k.fields.etaDate.replace(/\./g, '-');
         const timePart = String(n2k.fields.etaTime);

--- a/pgns/129794.js
+++ b/pgns/129794.js
@@ -23,6 +23,47 @@ module.exports = [
     value: n2k => n2k.fields.destination
   },
   {
+    node: 'navigation.destination.eta',
+    value: function (n2k) {
+      console.debug('etaDate', n2k.fields.etaDate)
+      if (typeof n2k.fields.etaDate === 'string') {
+        const datePart = n2k.fields.etaDate.replace(/\./g, '-');
+        const timePart = String(n2k.fields.etaTime);
+        const timeMatch = timePart.match(/^(\d+):(\d{2}):(\d{2})(\.\d+)?$/);
+        if (!timeMatch) {
+          const parsedDate = new Date(datePart + 'T00:00:00Z');
+          if (!Number.isFinite(parsedDate.getTime())) {
+            return undefined;
+          }
+          return parsedDate.toISOString();
+        }
+
+        const rawHours = Number(timeMatch[1]);
+        const rawMinutes = Number(timeMatch[2]);
+        const rawSeconds = Number(timeMatch[3]);
+        const fractional = timeMatch[4] ? Number(timeMatch[4]) : 0;
+
+        const hours = rawHours > 23 ? 0 : rawHours;
+        const minutes = rawMinutes > 59 ? 0 : rawMinutes;
+        const seconds = rawSeconds > 59 ? 0 : rawSeconds;
+        const totalSeconds = (hours * 3600) + (minutes * 60) + seconds + fractional;
+
+        const parsedDate = new Date(datePart + 'T00:00:00Z');
+        if (!Number.isFinite(parsedDate.getTime())) {
+          return undefined;
+        }
+        return new Date(parsedDate.getTime() + Math.round(totalSeconds * 1000)).toISOString();
+      }
+      const etaDate = Number(n2k.fields.etaDate);
+      const etaTime = Number(n2k.fields.etaTime);
+      if (!Number.isFinite(etaDate) || !Number.isFinite(etaTime) || etaDate <= 0) {
+        return undefined;
+      }
+      const etaMs = Date.UTC(1970, 0, 1) + (etaDate * 86400000) + (etaTime * 1000);
+      return new Date(etaMs).toISOString();
+    }
+  },
+  {
     node: 'design.draft',
     filter: function (n2k) {
       return n2k.fields.draft


### PR DESCRIPTION
I added the support for the path `navigation.destination.eta`

The specs defines `etaDate` and `etaTime` as Strings, Signal K expects one value a Date.

Tested with Signal K with dummy data from aava-n2k.data and live via Raymarine boat network.