### PR TITLE
chore: remove unused baconjs devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@signalk/server-api": "^1.39.0",
     "@signalk/signalk-schema": "1.3.1",
     "@tsconfig/node20": "^20.1.6",
-    "baconjs": "^1.0.1",
     "chai": "~4.1.0",
     "chai-things": "0.2",
     "mocha": "^7.1.0",


### PR DESCRIPTION
## Summary

baconjs is listed in devDependencies but not imported anywhere in the codebase or tests. Remove it.

## Testing

- All 181 unit tests pass.