### PR TITLE
add: Course API-aligned paths for route data

### DIFF
--- a/pgns/129285.js
+++ b/pgns/129285.js
@@ -92,7 +92,12 @@ module.exports = [
       )
     },
     filter: function (n2k, state) {
-      return hasState(state) && hasWaypoints(n2k, 3)
+      return (
+        hasState(state) &&
+        hasWaypoints(n2k, 3) &&
+        !_.isUndefined(n2k.fields.list[2].wpLatitude) &&
+        !_.isUndefined(n2k.fields.list[2].wpLongitude)
+      )
     },
     value: function (n2k) {
       return {

--- a/pgns/129285.js
+++ b/pgns/129285.js
@@ -11,12 +11,9 @@ module.exports = [
       )
     },
     filter: function (n2k, state) {
-      return (
-        typeof state === 'object' &&
-        typeof state.lastCourseCalculationType !== 'undefined'
-      )
+      return hasState(state)
     },
-    source: 'routeName'
+    source: 'routeName',
   },
   {
     node: function (n2k, state) {
@@ -27,16 +24,11 @@ module.exports = [
       )
     },
     filter: function (n2k, state) {
-      return (
-        typeof state === 'object' &&
-        typeof state.lastCourseCalculationType !== 'undefined' &&
-        !_.isUndefined(n2k.fields.list) &&
-        n2k.fields.list.length > 0
-      )
+      return hasState(state) && hasWaypoints(n2k, 1)
     },
     value: function (n2k) {
       return n2k.fields.list[0].wpName
-    }
+    },
   },
   {
     node: function (n2k, state) {
@@ -47,19 +39,14 @@ module.exports = [
       )
     },
     filter: function (n2k, state) {
-      return (
-        typeof state === 'object' &&
-        typeof state.lastCourseCalculationType !== 'undefined' &&
-        !_.isUndefined(n2k.fields.list) &&
-        n2k.fields.list.length > 0
-      )
+      return hasState(state) && hasWaypoints(n2k, 1)
     },
     value: function (n2k) {
       return {
         latitude: n2k.fields.list[0].wpLatitude,
-        longitude: n2k.fields.list[0].wpLongitude
+        longitude: n2k.fields.list[0].wpLongitude,
       }
-    }
+    },
   },
   {
     node: function (n2k, state) {
@@ -70,16 +57,11 @@ module.exports = [
       )
     },
     filter: function (n2k, state) {
-      return (
-        typeof state === 'object' &&
-        typeof state.lastCourseCalculationType !== 'undefined' &&
-        !_.isUndefined(n2k.fields.list) &&
-        n2k.fields.list.length > 1
-      )
+      return hasState(state) && hasWaypoints(n2k, 2)
     },
     value: function (n2k) {
       return n2k.fields.list[1].wpName
-    }
+    },
   },
   {
     node: function (n2k, state) {
@@ -91,17 +73,15 @@ module.exports = [
     },
     filter: function (n2k, state) {
       return (
-        typeof state === 'object' &&
-        typeof state.lastCourseCalculationType !== 'undefined' &&
-        !_.isUndefined(n2k.fields.list) &&
-        n2k.fields.list.length > 2 &&
+        hasState(state) &&
+        hasWaypoints(n2k, 3) &&
         !_.isUndefined(n2k.fields.list[2].wpLatitude) &&
         !_.isUndefined(n2k.fields.list[2].wpLongitude)
       )
     },
     value: function (n2k) {
       return n2k.fields.list[2].wpName
-    }
+    },
   },
   {
     node: function (n2k, state) {
@@ -112,18 +92,24 @@ module.exports = [
       )
     },
     filter: function (n2k, state) {
-      return (
-        typeof state === 'object' &&
-        typeof state.lastCourseCalculationType !== 'undefined' &&
-        !_.isUndefined(n2k.fields.list) &&
-        n2k.fields.list.length > 2
-      )
+      return hasState(state) && hasWaypoints(n2k, 3)
     },
     value: function (n2k) {
       return {
         latitude: n2k.fields.list[2].wpLatitude,
-        longitude: n2k.fields.list[2].wpLongitude
+        longitude: n2k.fields.list[2].wpLongitude,
       }
-    }
-  }
+    },
+  },
 ]
+
+function hasState(state) {
+  return (
+    typeof state === 'object' &&
+    typeof state.lastCourseCalculationType !== 'undefined'
+  )
+}
+
+function hasWaypoints(n2k, min) {
+  return !_.isUndefined(n2k.fields.list) && n2k.fields.list.length >= min
+}

--- a/pgns/129285.js
+++ b/pgns/129285.js
@@ -3,27 +3,127 @@ const _ = require('lodash')
 
 module.exports = [
   {
-    node: 'navigation.currentRoute.name',
+    node: function (n2k, state) {
+      return (
+        'navigation.course' +
+        state.lastCourseCalculationType +
+        '.activeRoute.name'
+      )
+    },
+    filter: function (n2k, state) {
+      return (
+        typeof state === 'object' &&
+        typeof state.lastCourseCalculationType !== 'undefined'
+      )
+    },
     source: 'routeName'
   },
   {
-    node: 'navigation.currentRoute.waypoints',
-    filter: n2k => {
-      return !_.isUndefined(n2k.fields.list)
+    node: function (n2k, state) {
+      return (
+        'navigation.course' +
+        state.lastCourseCalculationType +
+        '.previousPoint.name'
+      )
     },
-    value: n2k => {
-      var idx = 0
-      return n2k.fields.list.map(wp => {
-        return {
-          name: wp.wpName,
-          position: {
-            value: {
-              latitude: wp.wpLatitude,
-              longitude: wp.wpLongitude
-            }
-          }
-        }
-      })
+    filter: function (n2k, state) {
+      return (
+        typeof state === 'object' &&
+        typeof state.lastCourseCalculationType !== 'undefined' &&
+        !_.isUndefined(n2k.fields.list) &&
+        n2k.fields.list.length > 0
+      )
+    },
+    value: function (n2k) {
+      return n2k.fields.list[0].wpName
+    }
+  },
+  {
+    node: function (n2k, state) {
+      return (
+        'navigation.course' +
+        state.lastCourseCalculationType +
+        '.previousPoint.position'
+      )
+    },
+    filter: function (n2k, state) {
+      return (
+        typeof state === 'object' &&
+        typeof state.lastCourseCalculationType !== 'undefined' &&
+        !_.isUndefined(n2k.fields.list) &&
+        n2k.fields.list.length > 0
+      )
+    },
+    value: function (n2k) {
+      return {
+        latitude: n2k.fields.list[0].wpLatitude,
+        longitude: n2k.fields.list[0].wpLongitude
+      }
+    }
+  },
+  {
+    node: function (n2k, state) {
+      return (
+        'navigation.course' +
+        state.lastCourseCalculationType +
+        '.nextPoint.name'
+      )
+    },
+    filter: function (n2k, state) {
+      return (
+        typeof state === 'object' &&
+        typeof state.lastCourseCalculationType !== 'undefined' &&
+        !_.isUndefined(n2k.fields.list) &&
+        n2k.fields.list.length > 1
+      )
+    },
+    value: function (n2k) {
+      return n2k.fields.list[1].wpName
+    }
+  },
+  {
+    node: function (n2k, state) {
+      return (
+        'navigation.course' +
+        state.lastCourseCalculationType +
+        '.followingPoint.name'
+      )
+    },
+    filter: function (n2k, state) {
+      return (
+        typeof state === 'object' &&
+        typeof state.lastCourseCalculationType !== 'undefined' &&
+        !_.isUndefined(n2k.fields.list) &&
+        n2k.fields.list.length > 2 &&
+        !_.isUndefined(n2k.fields.list[2].wpLatitude) &&
+        !_.isUndefined(n2k.fields.list[2].wpLongitude)
+      )
+    },
+    value: function (n2k) {
+      return n2k.fields.list[2].wpName
+    }
+  },
+  {
+    node: function (n2k, state) {
+      return (
+        'navigation.course' +
+        state.lastCourseCalculationType +
+        '.followingPoint.position'
+      )
+    },
+    filter: function (n2k, state) {
+      return (
+        typeof state === 'object' &&
+        typeof state.lastCourseCalculationType !== 'undefined' &&
+        !_.isUndefined(n2k.fields.list) &&
+        n2k.fields.list.length > 2
+      )
+    },
+    value: function (n2k) {
+      return {
+        latitude: n2k.fields.list[2].wpLatitude,
+        longitude: n2k.fields.list[2].wpLongitude
+      }
     }
   }
 ]

--- a/test/129285_route_info.js
+++ b/test/129285_route_info.js
@@ -5,53 +5,106 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 
 var mapper = require('./testMapper')
 
+var state = {}
+
 describe('129285 Route Information', function () {
-  it('complete sentence converts', function () {
-    var msg = JSON.parse(
-      '{"timestamp":"2017-04-15T21:50:57.780Z","prio":6,"pgn":129285,"src":3,"dst":255,"fields":{"Start RPS#":12,"nItems":3,"Database ID":0,"Route ID":0,"Navigation direction in route":3,"Supplementary Route/WP data available":1,"Route Name":"Route","list":[{"WP ID":12,"WP Name":"Waypoint 240","WP Latitude":39.1525868,"WP Longitude":-76.1811988},{"WP ID":13,"WP Name":"Waypoint 241","WP Latitude":39.1568741,"WP Longitude":-76.1834715},{"WP ID":14,"WP Name":"Waypoint 242","WP Latitude":39.159168,"WP Longitude":-76.182178}]},"description":"Navigation - Route/WP Information"}'
+  it('3-waypoint message converts all points', function () {
+    mapper.toNested(
+      JSON.parse(
+        '{"timestamp":"2016-05-03T18:19:05.588Z","prio":3,"src":3,"dst":255,"pgn":129284,"description":"Navigation Data","fields":{"SID":231,"Distance to Waypoint":1910.38,"Course/Bearing reference":"True","Perpendicular Crossed":"No","Arrival Circle Entered":"No","Calculation Type":"Great Circle", "ETA Time": "03:01:46","ETA Date":"2016.05.04","Bearing, Origin to Destination Waypoint":2.6435,"Bearing, Position to Destination Waypoint":2.7651,"Origin Waypoint Number":0,"Destination Waypoint Number":1,"Destination Latitude":60.1366607,"Destination Longitude":24.9068518,"Waypoint Closing Velocity":0.06}}',
+      ),
+      state,
     )
-    var tree = mapper.toNested(msg)
-    tree.should.have.nested.property(
-      'navigation.currentRoute.name.value',
-      'Route'
-    )
-    tree.should.have.nested.property(
-      'navigation.currentRoute.waypoints.value[0].name',
-      'Waypoint 240'
-    )
-    tree.should.have.nested.property(
-      'navigation.currentRoute.waypoints.value[0].position.value.latitude',
-      39.1525868
-    )
-    tree.should.have.nested.property(
-      'navigation.currentRoute.waypoints.value[0].position.value.longitude',
-      -76.1811988
+    var tree = mapper.toNested(
+      JSON.parse(
+        '{"timestamp":"2017-04-15T21:50:57.780Z","prio":6,"pgn":129285,"src":3,"dst":255,"fields":{"Start RPS#":12,"nItems":3,"Database ID":0,"Route ID":0,"Navigation direction in route":3,"Supplementary Route/WP data available":1,"Route Name":"Route","list":[{"WP ID":12,"WP Name":"Waypoint 240","WP Latitude":39.1525868,"WP Longitude":-76.1811988},{"WP ID":13,"WP Name":"Waypoint 241","WP Latitude":39.1568741,"WP Longitude":-76.1834715},{"WP ID":14,"WP Name":"Waypoint 242","WP Latitude":39.159168,"WP Longitude":-76.182178}]},"description":"Navigation - Route/WP Information"}',
+      ),
+      state,
     )
 
     tree.should.have.nested.property(
-      'navigation.currentRoute.waypoints.value[1].name',
-      'Waypoint 241'
+      'navigation.courseGreatCircle.activeRoute.name.value',
+      'Route',
     )
     tree.should.have.nested.property(
-      'navigation.currentRoute.waypoints.value[1].position.value.latitude',
-      39.1568741
+      'navigation.courseGreatCircle.previousPoint.name.value',
+      'Waypoint 240',
     )
     tree.should.have.nested.property(
-      'navigation.currentRoute.waypoints.value[1].position.value.longitude',
-      -76.1834715
+      'navigation.courseGreatCircle.previousPoint.position.value.latitude',
+      39.1525868,
+    )
+    tree.should.have.nested.property(
+      'navigation.courseGreatCircle.previousPoint.position.value.longitude',
+      -76.1811988,
+    )
+    tree.should.have.nested.property(
+      'navigation.courseGreatCircle.nextPoint.name.value',
+      'Waypoint 241',
+    )
+    tree.should.have.nested.property(
+      'navigation.courseGreatCircle.followingPoint.name.value',
+      'Waypoint 242',
+    )
+    tree.should.have.nested.property(
+      'navigation.courseGreatCircle.followingPoint.position.value.latitude',
+      39.159168,
+    )
+    tree.should.have.nested.property(
+      'navigation.courseGreatCircle.followingPoint.position.value.longitude',
+      -76.182178,
+    )
+  })
+
+  it('2-waypoint message has no followingPoint', function () {
+    mapper.toNested(
+      JSON.parse(
+        '{"timestamp":"2016-05-03T18:19:05.588Z","prio":3,"src":3,"dst":255,"pgn":129284,"description":"Navigation Data","fields":{"SID":231,"Distance to Waypoint":1910.38,"Course/Bearing reference":"True","Perpendicular Crossed":"No","Arrival Circle Entered":"No","Calculation Type":"Great Circle", "ETA Time": "03:01:46","ETA Date":"2016.05.04","Bearing, Origin to Destination Waypoint":2.6435,"Bearing, Position to Destination Waypoint":2.7651,"Origin Waypoint Number":0,"Destination Waypoint Number":1,"Destination Latitude":60.1366607,"Destination Longitude":24.9068518,"Waypoint Closing Velocity":0.06}}',
+      ),
+      state,
+    )
+    var tree = mapper.toNested(
+      JSON.parse(
+        '{"timestamp":"2017-04-15T21:50:57.780Z","prio":6,"pgn":129285,"src":3,"dst":255,"fields":{"Start RPS#":12,"nItems":2,"Database ID":0,"Route ID":0,"Navigation direction in route":3,"Supplementary Route/WP data available":1,"Route Name":"Route","list":[{"WP ID":12,"WP Name":"Waypoint 240","WP Latitude":39.1525868,"WP Longitude":-76.1811988},{"WP ID":13,"WP Name":"Waypoint 241","WP Latitude":39.1568741,"WP Longitude":-76.1834715}]},"description":"Navigation - Route/WP Information"}',
+      ),
+      state,
     )
 
     tree.should.have.nested.property(
-      'navigation.currentRoute.waypoints.value[2].name',
-      'Waypoint 242'
+      'navigation.courseGreatCircle.activeRoute.name.value',
+      'Route',
     )
     tree.should.have.nested.property(
-      'navigation.currentRoute.waypoints.value[2].position.value.latitude',
-      39.159168
+      'navigation.courseGreatCircle.previousPoint.name.value',
+      'Waypoint 240',
     )
     tree.should.have.nested.property(
-      'navigation.currentRoute.waypoints.value[2].position.value.longitude',
-      -76.182178
+      'navigation.courseGreatCircle.nextPoint.name.value',
+      'Waypoint 241',
     )
+    tree.should.not.have.nested.property(
+      'navigation.courseGreatCircle.followingPoint',
+    )
+  })
+
+  it('without state produces no output', function () {
+    var tree = mapper.toNested(
+      JSON.parse(
+        '{"timestamp":"2017-04-15T21:50:57.780Z","prio":6,"pgn":129285,"src":3,"dst":255,"fields":{"Start RPS#":12,"nItems":3,"Database ID":0,"Route ID":0,"Navigation direction in route":3,"Supplementary Route/WP data available":1,"Route Name":"Route","list":[{"WP ID":12,"WP Name":"Waypoint 240","WP Latitude":39.1525868,"WP Longitude":-76.1811988},{"WP ID":13,"WP Name":"Waypoint 241","WP Latitude":39.1568741,"WP Longitude":-76.1834715},{"WP ID":14,"WP Name":"Waypoint 242","WP Latitude":39.159168,"WP Longitude":-76.182178}]},"description":"Navigation - Route/WP Information"}',
+      ),
+      {},
+    )
+    tree.should.not.have.nested.property('navigation.courseGreatCircle')
+    tree.should.not.have.nested.property('navigation.courseRhumbline')
+  })
+
+  it('null state does not crash', function () {
+    var tree = mapper.toNested(
+      JSON.parse(
+        '{"timestamp":"2017-04-15T21:50:57.780Z","prio":6,"pgn":129285,"src":3,"dst":255,"fields":{"Start RPS#":12,"nItems":3,"Database ID":0,"Route ID":0,"Navigation direction in route":3,"Supplementary Route/WP data available":1,"Route Name":"Route","list":[{"WP ID":12,"WP Name":"Waypoint 240","WP Latitude":39.1525868,"WP Longitude":-76.1811988},{"WP ID":13,"WP Name":"Waypoint 241","WP Latitude":39.1568741,"WP Longitude":-76.1834715},{"WP ID":14,"WP Name":"Waypoint 242","WP Latitude":39.159168,"WP Longitude":-76.182178}]},"description":"Navigation - Route/WP Information"}',
+      ),
+    )
+    tree.should.not.have.nested.property('navigation.courseGreatCircle')
+    tree.should.not.have.nested.property('navigation.courseRhumbline')
   })
 })


### PR DESCRIPTION
As the first step to implement the changes suggested in https://github.com/SignalK/n2k-signalk/issues/312 I added the proposed mappings to the following paths:
`navigation.course{calcType}.activeRoute.name`
`navigation.course{calcType}.previousPoint.name`
`navigation.course{calcType}.nextPoint.name`
`navigation.course{calcType}.previousPoint.position`
`navigation.course{calcType}.followingPoint.name`
`navigation.course{calcType}.followingPoint.position`

As suggested I also removed the paths to
`navigation.currentRoute.name` and `navigation.currentRoute.waypoints`

@dirkwa, please have I look if I missed something.