### PR TITLE
Revert "fix: use proper name for simrad AP nodrift"

### DIFF
--- a/simrad/65305.ts
+++ b/simrad/65305.ts
@@ -5,7 +5,7 @@ import {
 
 const modeMap: { [key: string]: SimnetApModeBitfield } = {
   'standby': SimnetApModeBitfield.Standby,
-  'nodrift': SimnetApModeBitfield.NoDrift,
+  'auto': SimnetApModeBitfield.NoDrift,
   'heading': SimnetApModeBitfield.Heading,
   'wind': SimnetApModeBitfield.Wind,
   'route': SimnetApModeBitfield.Nav


### PR DESCRIPTION
Reverts SignalK/n2k-signalk#316

Reverting for now because it is impossible to coordinate with the plugin.