### PR TITLE
perf: gate JSON.stringify behind debug.enabled in alert PGNs

### DIFF
--- a/pgns/126983.js
+++ b/pgns/126983.js
@@ -83,7 +83,9 @@ module.exports = [
       ) {
         value.method = []
       }
-      debug('126983 value: ' + JSON.stringify(value, null, 2))
+      if (debug.enabled) {
+        debug('126983 value: ' + JSON.stringify(value, null, 2))
+      }
 
       return value
     },

--- a/pgns/126985.js
+++ b/pgns/126985.js
@@ -17,7 +17,9 @@ module.exports = [
         }
         state.alerts[alertId] = text
 
-        debug('set alert state text: ' + JSON.stringify(text))
+        if (debug.enabled) {
+          debug('set alert state text: ' + JSON.stringify(text))
+        }
       }
       return false
     },


### PR DESCRIPTION
PGNs 126983 (alert) and 126985 (alert text) call

```js
debug('... ' + JSON.stringify(value, null, 2))
```

unconditionally per parsed message. With debug logging off (the production default) the `JSON.stringify` still runs eagerly, allocating short-lived strings that hammer the young-generation GC.

This is one of the bigger perf taxes a SignalK plugin pays: the serialize cost compounds with the GC pressure on hot paths. For reference, the same class of fix on `course-provider-plugin`'s dispatcher cut latency by ~70 % and dropped ~700 b/op of allocations on a single hot call site.

## Change

- `pgns/126983.js` — wrap with `if (debug.enabled)`.
- `pgns/126985.js` — same.

No behaviour change otherwise.