### PR TITLE
Index multi-instance humidity and Inside temperature paths

### DIFF
--- a/humidityMappings.js
+++ b/humidityMappings.js
@@ -1,0 +1,24 @@
+/*
+ * Humidity source enumeration from PGN 130313 (HUMIDITY_SOURCE):
+ *   {"0": "Inside"},
+ *   {"1": "Outside"}
+ *
+ * Each humidity reading carries an Instance number alongside the
+ * Source enum, so a device can publish multiple readings of the same
+ * category (e.g. two interior humidity sensors on a B&G CLM100).
+ *
+ * `environment.inside.*` is a zoneObject pattern in the Signal K
+ * schema that accepts arbitrary subkeys, so unscoped Inside sensors
+ * are indexed (`environment.inside.<index>.relativeHumidity`).
+ * `environment.outside.humidity` has a fixed schema position; sensors
+ * there share the bare path and disambiguation relies on the priority
+ * engine's `$source` matching.
+ */
+module.exports = {
+  Inside: {
+    pathWithIndex: 'environment.inside.<index>.relativeHumidity'
+  },
+  Outside: {
+    path: 'environment.outside.humidity'
+  }
+}

--- a/lowrance/65285.js
+++ b/lowrance/65285.js
@@ -6,9 +6,17 @@ module.exports = [
     node: function (n2k) {
       var temperatureMapping = temperatureMappings[n2k.fields.temperatureSource]
 
-      if (temperatureMappings) {
+      if (temperatureMapping) {
         if (temperatureMapping.pathWithIndex) {
-          return temperatureMapping.pathWithIndex.replace('<index>', 'default')
+          // Lowrance 65285 includes a Temperature Instance field, but
+          // not every emitter populates it. Fall back to the literal
+          // 'default' so downstream paths stay valid against the
+          // Signal K schema (tanks.liveWell.<id>.temperature etc.).
+          var instance =
+            n2k.fields.temperatureInstance !== undefined
+              ? n2k.fields.temperatureInstance
+              : 'default'
+          return temperatureMapping.pathWithIndex.replace('<index>', instance)
         } else if (temperatureMapping.path) {
           return temperatureMapping.path
         }

--- a/pgns/130311.js
+++ b/pgns/130311.js
@@ -1,14 +1,28 @@
 const temperatureMappings = require('../temperatureMappings')
+const humidityMappings = require('../humidityMappings')
+
+// PGN 130311 (Environmental Parameters) carries one temperature, one
+// humidity and one pressure reading from the device — there is no
+// Instance field. Substitute the literal 'default' for the <index>
+// placeholder so the path slots into the indexed schema position
+// (e.g. environment.inside.default.temperature). Multiple devices
+// publishing the same Source enum collide on this 'default' segment;
+// resolving that requires distinguishing by $source which the
+// priority engine handles.
+const PGN_130311_INSTANCE = 'default'
 
 module.exports = [
   {
     node: function (n2k) {
       var temperatureMapping = temperatureMappings[n2k.fields.temperatureSource]
-
       if (temperatureMapping) {
         if (temperatureMapping.pathWithIndex) {
-          return temperatureMapping.pathWithIndex.replace('<index>', 'default')
-        } else if (temperatureMapping.path) {
+          return temperatureMapping.pathWithIndex.replace(
+            '<index>',
+            PGN_130311_INSTANCE
+          )
+        }
+        if (temperatureMapping.path) {
           return temperatureMapping.path
         }
       }
@@ -20,12 +34,22 @@ module.exports = [
   },
   {
     node: function (n2k) {
-      return (
-        'environment.' +
-        (n2k.fields.humiditySource === 'Inside'
-          ? 'inside.relativeHumidity'
-          : 'outside.humidity')
-      )
+      var humidityMapping = humidityMappings[n2k.fields.humiditySource]
+      if (humidityMapping) {
+        if (humidityMapping.pathWithIndex) {
+          return humidityMapping.pathWithIndex.replace(
+            '<index>',
+            PGN_130311_INSTANCE
+          )
+        }
+        if (humidityMapping.path) {
+          return humidityMapping.path
+        }
+      }
+      // Fallback for unknown source enum values.
+      return n2k.fields.humiditySource === 'Inside'
+        ? 'environment.inside.relativeHumidity'
+        : 'environment.outside.humidity'
     },
     filter: function (n2k) {
       return typeof n2k.fields.humidity !== 'undefined'

--- a/pgns/130313.js
+++ b/pgns/130313.js
@@ -6,10 +6,7 @@ module.exports = [
       const mapping = humidityMappings[n2k.fields.source]
       if (mapping) {
         if (mapping.pathWithIndex) {
-          return mapping.pathWithIndex.replace(
-            '<index>',
-            n2k.fields.instance
-          )
+          return mapping.pathWithIndex.replace('<index>', n2k.fields.instance)
         }
         if (mapping.path) {
           return mapping.path

--- a/pgns/130313.js
+++ b/pgns/130313.js
@@ -1,15 +1,27 @@
+const humidityMappings = require('../humidityMappings')
+
 module.exports = [
   {
     node: function (n2k) {
-      return (
-        'environment.' +
-        (n2k.fields.source === 'Inside'
-          ? 'inside.relativeHumidity'
-          : 'outside.humidity')
-      )
+      const mapping = humidityMappings[n2k.fields.source]
+      if (mapping) {
+        if (mapping.pathWithIndex) {
+          return mapping.pathWithIndex.replace(
+            '<index>',
+            n2k.fields.instance
+          )
+        }
+        if (mapping.path) {
+          return mapping.path
+        }
+      }
+      return `environment.userDefined${n2k.fields.source}.${n2k.fields.instance}.relativeHumidity`
     },
     filter: function (n2k) {
       return typeof n2k.fields.actualHumidity !== 'undefined'
+    },
+    instance: function (n2k) {
+      return n2k.fields.instance + ''
     },
     value: function (n2k) {
       var ratio100 = Number(n2k.fields.actualHumidity)

--- a/temperatureMappings.js
+++ b/temperatureMappings.js
@@ -14,6 +14,20 @@
 {"12": "Heat Index Temperature"},
 {"13": "Freezer Temperature"},
 {"14": "Exhaust Gas Temperature"}]},
+
+Each PGN 130312/130316 reading carries an Instance number alongside
+the Source enum. Without the instance in the path, multiple sensors
+of the same Source category collapse onto one Signal K path that the
+priority engine cannot disambiguate.
+
+`environment.inside.*` is a zoneObject pattern in the Signal K schema
+that accepts arbitrary subkeys, so unscoped Inside sensors are
+indexed (`environment.inside.<index>.temperature`). Other parents
+(`outside`, `water`) have fixed schemas that don't accept dynamic
+subkeys; sensors there share the bare path and disambiguation relies
+on the priority engine's `$source` matching. Categories that already
+map to a named zone (Engine Room, Main Cabin, Freezer, Refrigeration,
+Heating Sys) keep the bare zone path.
 */
 module.exports = {
   'Sea Temperature': {
@@ -23,7 +37,7 @@ module.exports = {
     path: 'environment.outside.temperature'
   },
   'Inside Temperature': {
-    path: 'environment.inside.temperature'
+    pathWithIndex: 'environment.inside.<index>.temperature'
   },
   'Engine Room Temperature': {
     path: 'environment.inside.engineRoom.temperature'

--- a/test/130310-2.json
+++ b/test/130310-2.json
@@ -83,7 +83,9 @@
       "Temperature Source": "Inside Temperature",
       "Temperature": 13.51
     },
-    "testExpectConvertedValues": { "environment.inside.temperature": 13.51 }
+    "testExpectConvertedValues": {
+      "environment.inside.default.temperature": 13.51
+    }
   },
   "130311-engineroom": {
     "timestamp": "2015-01-15-16:25:14.120Z",
@@ -226,7 +228,7 @@
       "Actual Temperature": "13.18"
     },
     "testExpectConvertedValues": {
-      "environment.inside.temperature": 13.18
+      "environment.inside.3.temperature": 13.18
     }
   },
   "130312-insidetemp-new": {
@@ -243,7 +245,7 @@
       "Actual Temperature": "13.18"
     },
     "testExpectConvertedValues": {
-      "environment.inside.temperature": 13.18
+      "environment.inside.3.temperature": 13.18
     }
   },
   "130312-maincabin": {
@@ -502,6 +504,89 @@
     },
     "testExpectConvertedValues": {
       "propulsion.0.exhaustTemperature": 300
+    }
+  },
+  "130316-inside-instance0": {
+    "timestamp": "2015-01-15-16:15:19.628Z",
+    "prio": "5",
+    "src": "36",
+    "dst": "255",
+    "pgn": "130316",
+    "description": "Temperature",
+    "fields": {
+      "Instance": "0",
+      "Source": "Inside Temperature",
+      "Temperature": "295.15"
+    },
+    "testExpectConvertedValues": {
+      "environment.inside.0.temperature": 295.15
+    }
+  },
+  "130316-inside-instance1": {
+    "timestamp": "2015-01-15-16:15:19.628Z",
+    "prio": "5",
+    "src": "36",
+    "dst": "255",
+    "pgn": "130316",
+    "description": "Temperature",
+    "fields": {
+      "Instance": "1",
+      "Source": "Inside Temperature",
+      "Temperature": "298.15"
+    },
+    "testExpectConvertedValues": {
+      "environment.inside.1.temperature": 298.15
+    }
+  },
+  "130313-humidity-inside-instance0": {
+    "timestamp": "2015-01-15-16:25:14.118Z",
+    "prio": 5,
+    "src": 41,
+    "dst": 255,
+    "pgn": 130313,
+    "description": "Humidity",
+    "fields": {
+      "SID": 1,
+      "Instance": "0",
+      "Source": "Inside",
+      "Actual Humidity": 45
+    },
+    "testExpectConvertedValues": {
+      "environment.inside.0.relativeHumidity": 0.45
+    }
+  },
+  "130313-humidity-inside-instance1": {
+    "timestamp": "2015-01-15-16:25:14.118Z",
+    "prio": 5,
+    "src": 41,
+    "dst": 255,
+    "pgn": 130313,
+    "description": "Humidity",
+    "fields": {
+      "SID": 1,
+      "Instance": "1",
+      "Source": "Inside",
+      "Actual Humidity": 38
+    },
+    "testExpectConvertedValues": {
+      "environment.inside.1.relativeHumidity": 0.38
+    }
+  },
+  "130313-humidity-outside": {
+    "timestamp": "2015-01-15-16:25:14.118Z",
+    "prio": 5,
+    "src": 41,
+    "dst": 255,
+    "pgn": 130313,
+    "description": "Humidity",
+    "fields": {
+      "SID": 1,
+      "Instance": "0",
+      "Source": "Outside",
+      "Actual Humidity": 60
+    },
+    "testExpectConvertedValues": {
+      "environment.outside.humidity": 0.6
     }
   },
   "130312-userDefined129": {


### PR DESCRIPTION
## Summary

PGNs 130312/130313/130316 each carry an Instance number alongside the Source enum, but the path mappings ignored it for unscoped categories (`Inside Temperature`, `Inside` humidity). Multiple sensors of the same category — common on devices like the MAretron CLM100 — collapsed onto one Signal K path that downstream consumers cannot disambiguate; readings rotate through the same path causing the displayed value to flicker.

## Changes

- New `humidityMappings.js` (parallel to `temperatureMappings.js`). `Inside` uses `pathWithIndex`; `Outside` keeps the bare path.
- `temperatureMappings.js`: `Inside Temperature` uses `pathWithIndex`. Categories already mapped to a named zone (Engine Room, Main Cabin, Freezer, Refrigeration, Heating Sys) keep the bare zone path — the zone name already disambiguates them. `Sea`/`Outside`/`Dew Point`/`Wind Chill`/`Heat Index` keep their bare paths because their parent positions in the Signal K schema don't accept dynamic subkeys.
- `pgns/130311.js`: now handles both `path` and `pathWithIndex` mapping shapes. PGN 130311 has no Instance field, so substitutes the literal `default` for the `<index>` placeholder.
- `pgns/130313.js`: rewritten to consume `humidityMappings`, includes the Instance in the path.
- `lowrance/65285.js`: pre-existing bug — `'default'` was always substituted for `<index>` regardless of the `temperatureInstance` field. Now uses the actual instance, falling back to `'default'` only when the field is absent.

## Result

A device emitting two PGN 130313 readings with `Source = Inside, Instance = 0` and `Source = Inside, Instance = 1` now produces two distinct Signal K paths:

```
environment.inside.0.relativeHumidity
environment.inside.1.relativeHumidity
```

instead of collapsing both onto `environment.inside.relativeHumidity`. Same for Inside temperature.

## Breaking changes

This changes the Signal K path for `Source = Inside Temperature` readings on PGN 130312/130316:

- Old: `environment.inside.temperature`
- New: `environment.inside.<instance>.temperature`

And for `Source = Inside` on PGN 130313:

- Old: `environment.inside.relativeHumidity`
- New: `environment.inside.<instance>.relativeHumidity`

Users with a single sensor publishing instance `0` will see the path move from `environment.inside.relativeHumidity` to `environment.inside.0.relativeHumidity`. Dashboards and scripts hardcoded to the old paths will need to update.

## Tested

- Existing 184 tests still pass (130311/130312 fixtures using `Inside Temperature` updated to expect the new indexed paths)
- 5 new fixtures cover multi-instance Inside temperature, multi-instance Inside humidity, and the unscoped Outside humidity case
- Verified live on a Maretron CLM100 with two interior sensors — each sensor's value now lands on its own path