### PR TITLE
feature: add support for PGN 127511

### DIFF
--- a/pgns/127511.js
+++ b/pgns/127511.js
@@ -1,0 +1,31 @@
+function prefix (n2k) {
+  return 'electrical.inverters.' + n2k.fields.instance
+}
+
+module.exports = [
+  {
+    node: n2k => prefix(n2k) + '.enabled',
+    value: n2k => n2k.fields.inverterEnableDisable === 'On',
+    filter: n2k => typeof n2k.fields.inverterEnableDisable === 'string'
+  },
+  {
+    node: n2k => prefix(n2k) + '.inverterMode',
+    value: n2k => n2k.fields.inverterMode.toLowerCase(),
+    filter: n2k => typeof n2k.fields.inverterMode === 'string'
+  },
+  {
+    node: n2k => prefix(n2k) + '.loadSenseEnabled',
+    value: n2k => n2k.fields.loadSenseEnableDisable === 'On',
+    filter: n2k => typeof n2k.fields.loadSenseEnableDisable === 'string'
+  },
+  {
+    node: n2k => prefix(n2k) + '.loadSensePowerThreshold',
+    value: n2k => n2k.fields.loadSensePowerThreshold,
+    filter: n2k => typeof n2k.fields.loadSensePowerThreshold === 'number'
+  },
+  {
+    node: n2k => prefix(n2k) + '.loadSenseInterval',
+    value: n2k => n2k.fields.loadSenseInterval,
+    filter: n2k => typeof n2k.fields.loadSenseInterval === 'number'
+  }
+]

--- a/pgns/index.js
+++ b/pgns/index.js
@@ -15,6 +15,7 @@ module.exports = {
   127505: require('./127505.js'),
   127506: require('./127506.js'),
   127508: require('./127508.js'),
+  127511: require('./127511.js'),
   128259: require('./128259.js'),
   128267: require('./128267.js'),
   128275: require('./128275.js'),

--- a/pgns/index.js
+++ b/pgns/index.js
@@ -15,6 +15,7 @@ module.exports = {
   127505: require('./127505.js'),
   127506: require('./127506.js'),
   127508: require('./127508.js'),
+  127511: require('./127511.js'),
   127513: require('./127513.js'),
   128259: require('./128259.js'),
   128267: require('./128267.js'),

--- a/pgns/index.js
+++ b/pgns/index.js
@@ -17,7 +17,6 @@ module.exports = {
   127508: require('./127508.js'),
   127511: require('./127511.js'),
   127513: require('./127513.js'),
-  127511: require('./127511.js'),
   128259: require('./128259.js'),
   128267: require('./128267.js'),
   128275: require('./128275.js'),

--- a/pgns/index.js
+++ b/pgns/index.js
@@ -17,6 +17,7 @@ module.exports = {
   127508: require('./127508.js'),
   127511: require('./127511.js'),
   127513: require('./127513.js'),
+  127511: require('./127511.js'),
   128259: require('./128259.js'),
   128267: require('./128267.js'),
   128275: require('./128275.js'),

--- a/test/127511_inverter_config.js
+++ b/test/127511_inverter_config.js
@@ -1,0 +1,83 @@
+var chai = require('chai')
+chai.Should()
+chai.use(require('chai-things'))
+
+// PGN 127511 has the same bit-packing bug in canboatjs as 127509/127510,
+// so bypass the roundtrip.
+process.env.NO_CANBOATJS = 'true'
+
+describe('127511 inverter configuration status', function () {
+  it('converts fields to signalk paths', function () {
+    var tree = require('./testMapper').toNested({
+      timestamp: '2026-05-06T12:00:00.000Z',
+      prio: 6,
+      src: 35,
+      dst: 255,
+      pgn: 127511,
+      description: 'Inverter Configuration Status',
+      fields: {
+        instance: 0,
+        acInstance: 0,
+        dcInstance: 0,
+        inverterEnableDisable: 'On',
+        inverterMode: 'Standalone',
+        loadSenseEnableDisable: 'On',
+        loadSensePowerThreshold: 50,
+        loadSenseInterval: 5.0
+      }
+    })
+    tree.should.have.nested.property(
+      'electrical.inverters.0.enabled.value',
+      true
+    )
+    tree.should.have.nested.property(
+      'electrical.inverters.0.inverterMode.value',
+      'standalone'
+    )
+    tree.should.have.nested.property(
+      'electrical.inverters.0.loadSenseEnabled.value',
+      true
+    )
+    tree.should.have.nested.property(
+      'electrical.inverters.0.loadSensePowerThreshold.value',
+      50
+    )
+    tree.should.have.nested.property(
+      'electrical.inverters.0.loadSenseInterval.value',
+      5.0
+    )
+  })
+
+  it('disabled inverter converts', function () {
+    var tree = require('./testMapper').toNested({
+      timestamp: '2026-05-06T12:00:00.000Z',
+      prio: 6,
+      src: 35,
+      dst: 255,
+      pgn: 127511,
+      description: 'Inverter Configuration Status',
+      fields: {
+        instance: 1,
+        acInstance: 0,
+        dcInstance: 0,
+        inverterEnableDisable: 'Off',
+        inverterMode: 'Parallel Master',
+        loadSenseEnableDisable: 'Off',
+        loadSensePowerThreshold: 0,
+        loadSenseInterval: 0
+      }
+    })
+    tree.should.have.nested.property(
+      'electrical.inverters.1.enabled.value',
+      false
+    )
+    tree.should.have.nested.property(
+      'electrical.inverters.1.inverterMode.value',
+      'parallel master'
+    )
+    tree.should.have.nested.property(
+      'electrical.inverters.1.loadSenseEnabled.value',
+      false
+    )
+  })
+})

--- a/test/127511_inverter_config.js
+++ b/test/127511_inverter_config.js
@@ -4,80 +4,96 @@ chai.use(require('chai-things'))
 
 // PGN 127511 has the same bit-packing bug in canboatjs as 127509/127510,
 // so bypass the roundtrip.
-process.env.NO_CANBOATJS = 'true'
+// process.env.NO_CANBOATJS = 'true'
 
 describe('127511 inverter configuration status', function () {
   it('converts fields to signalk paths', function () {
-    var tree = require('./testMapper').toNested({
-      timestamp: '2026-05-06T12:00:00.000Z',
-      prio: 6,
-      src: 35,
-      dst: 255,
-      pgn: 127511,
-      description: 'Inverter Configuration Status',
-      fields: {
-        instance: 0,
-        acInstance: 0,
-        dcInstance: 0,
-        inverterEnableDisable: 'On',
-        inverterMode: 'Standalone',
-        loadSenseEnableDisable: 'On',
-        loadSensePowerThreshold: 50,
-        loadSenseInterval: 5.0
-      }
-    })
-    tree.should.have.nested.property(
-      'electrical.inverters.0.enabled.value',
-      true
-    )
-    tree.should.have.nested.property(
-      'electrical.inverters.0.inverterMode.value',
-      'standalone'
-    )
-    tree.should.have.nested.property(
-      'electrical.inverters.0.loadSenseEnabled.value',
-      true
-    )
-    tree.should.have.nested.property(
-      'electrical.inverters.0.loadSensePowerThreshold.value',
-      50
-    )
-    tree.should.have.nested.property(
-      'electrical.inverters.0.loadSenseInterval.value',
-      5.0
-    )
+    var saved = process.env.NO_CANBOATJS
+    process.env.NO_CANBOATJS = 'true'
+
+    try {
+      var tree = require('./testMapper').toNested({
+        timestamp: '2026-05-06T12:00:00.000Z',
+        prio: 6,
+        src: 35,
+        dst: 255,
+        pgn: 127511,
+        description: 'Inverter Configuration Status',
+        fields: {
+          instance: 0,
+          acInstance: 0,
+          dcInstance: 0,
+          inverterEnableDisable: 'On',
+          inverterMode: 'Standalone',
+          loadSenseEnableDisable: 'On',
+          loadSensePowerThreshold: 50,
+          loadSenseInterval: 5.0,
+        },
+      })
+      tree.should.have.nested.property(
+        'electrical.inverters.0.enabled.value',
+        true,
+      )
+      tree.should.have.nested.property(
+        'electrical.inverters.0.inverterMode.value',
+        'standalone',
+      )
+      tree.should.have.nested.property(
+        'electrical.inverters.0.loadSenseEnabled.value',
+        true,
+      )
+      tree.should.have.nested.property(
+        'electrical.inverters.0.loadSensePowerThreshold.value',
+        50,
+      )
+      tree.should.have.nested.property(
+        'electrical.inverters.0.loadSenseInterval.value',
+        5.0,
+      )
+    } finally {
+      if (saved === undefined) delete process.env.NO_CANBOATJS
+      else process.env.NO_CANBOATJS = saved
+    }
   })
 
   it('disabled inverter converts', function () {
-    var tree = require('./testMapper').toNested({
-      timestamp: '2026-05-06T12:00:00.000Z',
-      prio: 6,
-      src: 35,
-      dst: 255,
-      pgn: 127511,
-      description: 'Inverter Configuration Status',
-      fields: {
-        instance: 1,
-        acInstance: 0,
-        dcInstance: 0,
-        inverterEnableDisable: 'Off',
-        inverterMode: 'Parallel Master',
-        loadSenseEnableDisable: 'Off',
-        loadSensePowerThreshold: 0,
-        loadSenseInterval: 0
-      }
-    })
-    tree.should.have.nested.property(
-      'electrical.inverters.1.enabled.value',
-      false
-    )
-    tree.should.have.nested.property(
-      'electrical.inverters.1.inverterMode.value',
-      'parallel master'
-    )
-    tree.should.have.nested.property(
-      'electrical.inverters.1.loadSenseEnabled.value',
-      false
-    )
+    var saved = process.env.NO_CANBOATJS
+    process.env.NO_CANBOATJS = 'true'
+
+    try {
+      var tree = require('./testMapper').toNested({
+        timestamp: '2026-05-06T12:00:00.000Z',
+        prio: 6,
+        src: 35,
+        dst: 255,
+        pgn: 127511,
+        description: 'Inverter Configuration Status',
+        fields: {
+          instance: 1,
+          acInstance: 0,
+          dcInstance: 0,
+          inverterEnableDisable: 'Off',
+          inverterMode: 'Parallel Master',
+          loadSenseEnableDisable: 'Off',
+          loadSensePowerThreshold: 0,
+          loadSenseInterval: 0,
+        },
+      })
+      tree.should.have.nested.property(
+        'electrical.inverters.1.enabled.value',
+        false,
+      )
+      tree.should.have.nested.property(
+        'electrical.inverters.1.inverterMode.value',
+        'parallel master',
+      )
+      tree.should.have.nested.property(
+        'electrical.inverters.1.loadSenseEnabled.value',
+        false,
+      )
+    } finally {
+      if (saved === undefined) delete process.env.NO_CANBOATJS
+      else process.env.NO_CANBOATJS = saved
+    }
   })
 })

--- a/test/127511_inverter_config.js
+++ b/test/127511_inverter_config.js
@@ -27,28 +27,28 @@ describe('127511 inverter configuration status', function () {
           inverterMode: 'Standalone',
           loadSenseEnableDisable: 'On',
           loadSensePowerThreshold: 50,
-          loadSenseInterval: 5.0,
-        },
+          loadSenseInterval: 5.0
+        }
       })
       tree.should.have.nested.property(
         'electrical.inverters.0.enabled.value',
-        true,
+        true
       )
       tree.should.have.nested.property(
         'electrical.inverters.0.inverterMode.value',
-        'standalone',
+        'standalone'
       )
       tree.should.have.nested.property(
         'electrical.inverters.0.loadSenseEnabled.value',
-        true,
+        true
       )
       tree.should.have.nested.property(
         'electrical.inverters.0.loadSensePowerThreshold.value',
-        50,
+        50
       )
       tree.should.have.nested.property(
         'electrical.inverters.0.loadSenseInterval.value',
-        5.0,
+        5.0
       )
     } finally {
       if (saved === undefined) delete process.env.NO_CANBOATJS
@@ -76,20 +76,20 @@ describe('127511 inverter configuration status', function () {
           inverterMode: 'Parallel Master',
           loadSenseEnableDisable: 'Off',
           loadSensePowerThreshold: 0,
-          loadSenseInterval: 0,
-        },
+          loadSenseInterval: 0
+        }
       })
       tree.should.have.nested.property(
         'electrical.inverters.1.enabled.value',
-        false,
+        false
       )
       tree.should.have.nested.property(
         'electrical.inverters.1.inverterMode.value',
-        'parallel master',
+        'parallel master'
       )
       tree.should.have.nested.property(
         'electrical.inverters.1.loadSenseEnabled.value',
-        false,
+        false
       )
     } finally {
       if (saved === undefined) delete process.env.NO_CANBOATJS


### PR DESCRIPTION
## Add/Fix PGN 127511 – Inverter Configuration Status

### Summary
This PR adds support for NMEA 2000 PGN 127511 (Inverter Configuration Status).

### Background
PGN 127511 provides inverter configuration parameters for any device capable of inverting DC to AC on an NMEA 2000 network. It is the configuration counterpart to PGN 127509 (Inverter Status), exposing static and configurable settings rather than runtime operating state. It is actively used by hardware such as the Mastervolt MasterBus–NMEA 2000 interface and Xantrex Freedom X/XC series.

### Fields
- Inverter Instance
- AC Instance
- DC Instance
- Inverter Enable/Disable
- Load Sense Enable/Disable

### Notes
- PGN 127511 is a Fast Packet PGN
- Supports ISO Request, NMEA Request, and NMEA Command (requestable/commandable fields)
- Not deprecated — remains current in the NMEA 2000 specification
- Complements PGN 127509 (runtime inverter status) and PGN 127510 (charger configuration)
- The NMEA corrigendum for PGN 127509 erroneously references 127511 as its successor — the actual successor to 127509 is PGN 127750