### PR TITLE
feature: add support for PGN 127513

### DIFF
--- a/pgns/127513.js
+++ b/pgns/127513.js
@@ -24,7 +24,7 @@ module.exports = [
     filter: n2k => typeof n2k.fields.chemistry === 'string'
   },
   {
-    node: n2k => prefix(n2k) + '.capacity',
+    node: n2k => prefix(n2k) + '.capacity.nominal',
     value: n2k => n2k.fields.capacity * 3600,
     filter: n2k => typeof n2k.fields.capacity === 'number'
   },

--- a/pgns/127513.js
+++ b/pgns/127513.js
@@ -1,0 +1,46 @@
+function prefix (n2k) {
+  return 'electrical.batteries.' + n2k.fields.instance
+}
+
+module.exports = [
+  {
+    node: n2k => prefix(n2k) + '.batteryType',
+    value: n2k => n2k.fields.batteryType.toLowerCase(),
+    filter: n2k => typeof n2k.fields.batteryType === 'string'
+  },
+  {
+    node: n2k => prefix(n2k) + '.supportsEqualization',
+    value: n2k => n2k.fields.supportsEqualization === 'Yes',
+    filter: n2k => typeof n2k.fields.supportsEqualization === 'string'
+  },
+  {
+    node: n2k => prefix(n2k) + '.nominalVoltage',
+    value: n2k => n2k.fields.nominalVoltage,
+    filter: n2k => typeof n2k.fields.nominalVoltage === 'string'
+  },
+  {
+    node: n2k => prefix(n2k) + '.chemistry',
+    value: n2k => n2k.fields.chemistry.toLowerCase(),
+    filter: n2k => typeof n2k.fields.chemistry === 'string'
+  },
+  {
+    node: n2k => prefix(n2k) + '.capacity',
+    value: n2k => n2k.fields.capacity * 3600,
+    filter: n2k => typeof n2k.fields.capacity === 'number'
+  },
+  {
+    node: n2k => prefix(n2k) + '.temperatureCoefficient',
+    value: n2k => n2k.fields.temperatureCoefficient,
+    filter: n2k => typeof n2k.fields.temperatureCoefficient === 'number'
+  },
+  {
+    node: n2k => prefix(n2k) + '.peukertExponent',
+    value: n2k => n2k.fields.peukertExponent,
+    filter: n2k => typeof n2k.fields.peukertExponent === 'number'
+  },
+  {
+    node: n2k => prefix(n2k) + '.chargeEfficiencyFactor',
+    value: n2k => n2k.fields.chargeEfficiencyFactor,
+    filter: n2k => typeof n2k.fields.chargeEfficiencyFactor === 'number'
+  }
+]

--- a/pgns/index.js
+++ b/pgns/index.js
@@ -15,6 +15,7 @@ module.exports = {
   127505: require('./127505.js'),
   127506: require('./127506.js'),
   127508: require('./127508.js'),
+  127513: require('./127513.js'),
   128259: require('./128259.js'),
   128267: require('./128267.js'),
   128275: require('./128275.js'),

--- a/test/127513_battery_config.js
+++ b/test/127513_battery_config.js
@@ -44,7 +44,7 @@ describe('127513 battery configuration status', function () {
       'pb (lead)'
     )
     tree.should.have.nested.property(
-      'electrical.batteries.0.capacity.value',
+      'electrical.batteries.0.capacity.nominal.value',
       360000
     )
     tree.should.have.nested.property(
@@ -90,7 +90,7 @@ describe('127513 battery configuration status', function () {
       false
     )
     tree.should.have.nested.property(
-      'electrical.batteries.1.capacity.value',
+      'electrical.batteries.1.capacity.nominal.value',
       720000
     )
   })

--- a/test/127513_battery_config.js
+++ b/test/127513_battery_config.js
@@ -1,0 +1,97 @@
+var chai = require('chai')
+chai.Should()
+chai.use(require('chai-things'))
+
+// PGN 127513 has sub-byte fields with non-zero BitStart, triggering the
+// canboatjs bit-packing bug — bypass the roundtrip.
+process.env.NO_CANBOATJS = 'true'
+
+describe('127513 battery configuration status', function () {
+  it('converts fields to signalk paths', function () {
+    var tree = require('./testMapper').toNested({
+      timestamp: '2026-05-06T12:00:00.000Z',
+      prio: 6,
+      src: 35,
+      dst: 255,
+      pgn: 127513,
+      description: 'Battery Configuration Status',
+      fields: {
+        instance: 0,
+        batteryType: 'AGM',
+        supportsEqualization: 'Yes',
+        nominalVoltage: '12V',
+        chemistry: 'Pb (Lead)',
+        capacity: 100,
+        temperatureCoefficient: -5,
+        peukertExponent: 1.25,
+        chargeEfficiencyFactor: 90
+      }
+    })
+    tree.should.have.nested.property(
+      'electrical.batteries.0.batteryType.value',
+      'agm'
+    )
+    tree.should.have.nested.property(
+      'electrical.batteries.0.supportsEqualization.value',
+      true
+    )
+    tree.should.have.nested.property(
+      'electrical.batteries.0.nominalVoltage.value',
+      '12V'
+    )
+    tree.should.have.nested.property(
+      'electrical.batteries.0.chemistry.value',
+      'pb (lead)'
+    )
+    tree.should.have.nested.property(
+      'electrical.batteries.0.capacity.value',
+      360000
+    )
+    tree.should.have.nested.property(
+      'electrical.batteries.0.temperatureCoefficient.value',
+      -5
+    )
+    tree.should.have.nested.property(
+      'electrical.batteries.0.peukertExponent.value',
+      1.25
+    )
+    tree.should.have.nested.property(
+      'electrical.batteries.0.chargeEfficiencyFactor.value',
+      90
+    )
+  })
+
+  it('no equalization battery', function () {
+    var tree = require('./testMapper').toNested({
+      timestamp: '2026-05-06T12:00:00.000Z',
+      prio: 6,
+      src: 35,
+      dst: 255,
+      pgn: 127513,
+      description: 'Battery Configuration Status',
+      fields: {
+        instance: 1,
+        batteryType: 'Flooded',
+        supportsEqualization: 'No',
+        nominalVoltage: '24V',
+        chemistry: 'Li',
+        capacity: 200,
+        temperatureCoefficient: 0,
+        peukertExponent: 1.05,
+        chargeEfficiencyFactor: 95
+      }
+    })
+    tree.should.have.nested.property(
+      'electrical.batteries.1.batteryType.value',
+      'flooded'
+    )
+    tree.should.have.nested.property(
+      'electrical.batteries.1.supportsEqualization.value',
+      false
+    )
+    tree.should.have.nested.property(
+      'electrical.batteries.1.capacity.value',
+      720000
+    )
+  })
+})


### PR DESCRIPTION
## Add/Fix PGN 127513 – Battery Configuration Status

### Summary
This PR adds support for NMEA 2000 PGN 127513 (Battery Configuration Status).

### Background
PGN 127513 provides static configuration parameters for a specific battery instance on an NMEA 2000 network. It is the configuration counterpart to PGN 127508 (Battery Status) and PGN 127506 (DC Detailed Status), and is widely used by battery monitors, BMS devices, and inverter/charger bridges. It is actively transmitted by hardware such as the Mastervolt MasterBus–NMEA 2000 interface, Xantrex Freedom X/XC, and certified battery monitors from Yacht Devices, Lithium Pros, and others.

### Fields
- Battery Instance
- Battery Type (e.g. Flooded, Gel, AGM, Lithium)
- Supports Equalization
- Nominal Voltage
- Chemistry
- Nominal Capacity (Ah)
- Peukert Exponent
- Charge Efficiency Factor
- Discharge Rate (nominal)
- Fully Charged Voltage

### Notes
- PGN 127513 is a Fast Packet PGN
- Supports ISO Request, NMEA Request, and NMEA Command (requestable/commandable fields)
- Not deprecated — remains current in the NMEA 2000 specification
- Essential context for correctly interpreting SoC and time-remaining values from PGN 127506, as capacity and Peukert exponent directly affect those calculations
- One of the three core battery PGNs alongside 127506 and 127508