### PR TITLE
fix: guard against undefined fields in PGN 130312 Temperature handler

### DIFF
--- a/pgns/130312.js
+++ b/pgns/130312.js
@@ -3,12 +3,15 @@ const temperatureMappings = require('../temperatureMappings')
 module.exports = [
   {
     node: function (n2k) {
+      if (n2k.fields.source == null) {
+        return null
+      }
       var temperatureMapping = temperatureMappings[n2k.fields.source]
       if (temperatureMapping) {
         if (temperatureMapping.pathWithIndex) {
           return temperatureMapping.pathWithIndex.replace(
             '<index>',
-            n2k.fields.instance
+            n2k.fields.instance != null ? n2k.fields.instance : 0
           )
         } else if (temperatureMapping.path) {
           return temperatureMapping.path
@@ -16,11 +19,13 @@ module.exports = [
       } else {
         return `generic.temperatures.userDefined${n2k.fields.source
           .toString()
-          .replace(/\ /g, '_')}.${n2k.fields.instance}.temperature`
+          .replace(/\ /g, '_')}.${
+          n2k.fields.instance != null ? n2k.fields.instance : 0
+        }.temperature`
       }
     },
     instance: function (n2k) {
-      return n2k.fields.instance + ''
+      return n2k.fields.instance != null ? n2k.fields.instance + '' : null
     },
     source: 'actualTemperature'
   }

--- a/test/13031_temperature.js
+++ b/test/13031_temperature.js
@@ -4,6 +4,7 @@ chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 var debug = require('debug')('n2k-signalk:test:130312')
 var _ = require('lodash')
+var assert = require('assert')
 
 describe('Temperature: ', function () {
   var n2kMapper = require('./testMapper')
@@ -48,6 +49,22 @@ describe('Temperature: ', function () {
         fullDoc.should.be.validSignalK
       }
     })
+  })
+
+  it('does not throw for PGN 130312 with empty fields (Lowrance HDS-8 / SA=3)', function () {
+    // Hardware such as Lowrance HDS-8 (SA=3) can broadcast Temperature PGNs
+    // with no data fields. Empty Temperature PGNs are valid on the NMEA 2000
+    // bus. The handler must not throw when fields is {}.
+    var delta = n2kMapper.toDelta({
+      timestamp: '2024-01-01T00:00:00.000Z',
+      prio: 5,
+      src: 3,
+      dst: 255,
+      pgn: 130312,
+      description: 'Temperature',
+      fields: {}
+    })
+    assert.equal(delta.updates[0].values.length, 0)
   })
 
   it('all 130312 mappings are valid', function () {


### PR DESCRIPTION
## Problem

The PGN 130312 Temperature handler throws a TypeError when a device sends a Temperature PGN with no data fields:

```
TypeError: Cannot read properties of undefined (reading 'toString')
    at Object.node (.../pgns/130312.js:17:22)
```

This was observed with a Lowrance HDS-8 (Source Address 3) broadcasting Temperature PGNs with `fields: {}`. Empty Temperature PGNs are valid on the NMEA 2000 bus.

The error recurs on every such PGN, flooding the Signal K server logs with a new `TypeError` line each time the device transmits.

### Root Cause

In `pgns/130312.js`, when `n2k.fields.source` is `undefined` (because `fields` is `{}`), the `else` branch at line 17 attempts:

```js
return `generic.temperatures.userDefined${n2k.fields.source
  .toString()    // ← TypeError: Cannot read properties of undefined
  ...
```

The mapper's `catch` block in `reduceMapping` absorbs the exception and continues, so the delta is returned with no values — but the error is still written to stderr on every occurrence.

## Fix

Add a null guard at the top of the `node` function so that an empty/missing `source` field returns `null` immediately (causing the mapping to be skipped cleanly). Also guard `instance` accesses in the `pathWithIndex` replacement and in the `instance` helper.

```js
// Before:
node: function (n2k) {
  var temperatureMapping = temperatureMappings[n2k.fields.source]
  ...
  } else {
    return `generic.temperatures.userDefined${n2k.fields.source
      .toString()   // ← throws when source is undefined
      .replace(/\ /g, '_')}.${n2k.fields.instance}.temperature`
  }
}

// After:
node: function (n2k) {
  if (n2k.fields.source == null) {
    return null           // skip cleanly — no TypeError, no log spam
  }
  var temperatureMapping = temperatureMappings[n2k.fields.source]
  ...
}
```

## Test

Added a regression test in `test/13031_temperature.js` that passes a Temperature frame with `fields: {}` directly through `mapper.toDelta()` and asserts it returns a delta with no values and does not throw.

## Reproduction

Any N2K device on the bus that broadcasts PGN 130312 with no data fields will trigger this. Confirmed on a live vessel with a Lowrance HDS-8 chartplotter.