### PR TITLE
fix(126983): default non-standard alertType to 'alert' state

### DIFF
--- a/pgns/126983.js
+++ b/pgns/126983.js
@@ -20,12 +20,30 @@ const alertTypes = [
   }
 ]
 
+// Devices in the wild emit non-spec ALERT_TYPE values (e.g. 4) that
+// canboatjs returns as raw integers. Default those to Caution → 'alert'
+// so the notification still surfaces at the lowest severity.
+const defaultAlertType = alertTypes[alertTypes.length - 1]
+
+function resolveAlertType (rawAlertType) {
+  if (typeof rawAlertType === 'string') {
+    for (var i = 0; i < alertTypes.length; i++) {
+      if (alertTypes[i].nmea === rawAlertType) return alertTypes[i]
+    }
+  }
+  return defaultAlertType
+}
+
 module.exports = [
   {
     node: function (n2k, state) {
-      var alertType = n2k.fields.alertType.replace(/ /g, '').toLowerCase()
+      var resolved = resolveAlertType(n2k.fields.alertType)
+      var alertType = resolved.nmea.replace(/ /g, '').toLowerCase()
 
-      var alertCategory = (n2k.fields.alertCategory || '').toLowerCase()
+      var alertCategory =
+        typeof n2k.fields.alertCategory === 'string'
+          ? n2k.fields.alertCategory.toLowerCase()
+          : ''
 
       var path =
         'notifications.nmea.' +
@@ -43,15 +61,13 @@ module.exports = [
     value: function (n2k, state) {
       debug('126983 value')
 
-      var skstate = alertTypes.filter(
-        alertType => alertType.nmea === n2k.fields.alertType
-      )
-      debug('126983 skstate: ' + skstate[0].sk)
+      var resolved = resolveAlertType(n2k.fields.alertType)
+      debug('126983 skstate: ' + resolved.sk)
 
       var alertId = n2k.fields.alertId
 
       var value = {
-        state: skstate[0].sk,
+        state: resolved.sk,
         method: ['visual', 'sound'],
         message: state.alerts[alertId].textDescription,
         alertType: n2k.fields.alertType,
@@ -88,17 +104,9 @@ module.exports = [
       return value
     },
     filter: function (n2k, state) {
-      // Some devices emit non-standard alertType values (e.g. 4) that
-      // canboatjs cannot resolve via the ALERT_TYPE enum. In that case
-      // the value falls through as a raw integer and the path/value
-      // builders above blow up on `.replace` / `alertTypes.filter[0].sk`.
-      // Only accept frames where alertType matches one of the four
-      // values defined in the canboat ALERT_TYPE enum.
       return (
-        typeof n2k.fields.alertType === 'string' &&
-        alertTypes.some(function (a) {
-          return a.nmea === n2k.fields.alertType
-        }) &&
+        n2k.fields.alertType !== undefined &&
+        n2k.fields.alertType !== null &&
         typeof state === 'object' &&
         state.alerts &&
         state.alerts[n2k.fields.alertId]

--- a/pgns/126983.js
+++ b/pgns/126983.js
@@ -88,8 +88,17 @@ module.exports = [
       return value
     },
     filter: function (n2k, state) {
+      // Some devices emit non-standard alertType values (e.g. 4) that
+      // canboatjs cannot resolve via the ALERT_TYPE enum. In that case
+      // the value falls through as a raw integer and the path/value
+      // builders above blow up on `.replace` / `alertTypes.filter[0].sk`.
+      // Only accept frames where alertType matches one of the four
+      // values defined in the canboat ALERT_TYPE enum.
       return (
-        n2k.fields.alertType &&
+        typeof n2k.fields.alertType === 'string' &&
+        alertTypes.some(function (a) {
+          return a.nmea === n2k.fields.alertType
+        }) &&
         typeof state === 'object' &&
         state.alerts &&
         state.alerts[n2k.fields.alertId]

--- a/test/126983_alert.js
+++ b/test/126983_alert.js
@@ -102,4 +102,39 @@ describe('126983 Alert', function () {
     var delta = mapper.testToDelta(msg)
     delta.updates.length.should.equal(1)
   })
+
+  it('skips alerts with non-standard (integer) alertType without throwing', function () {
+    // Some devices emit alertType values outside the canboat ALERT_TYPE
+    // enum (1,2,5,8). canboatjs returns the raw integer in that case;
+    // previously the mapper crashed in node() and value() trying to call
+    // .replace on a number. The filter should drop these frames cleanly.
+    var msg = {
+      canId: 166725504,
+      prio: 2,
+      src: 128,
+      pgn: 126983,
+      dst: 255,
+      fields: {
+        alertType: 4,
+        alertCategory: 6,
+        alertSystem: 4
+      },
+      description: 'Alert',
+      id: 'alert',
+      timestamp: '2024-01-01T00:00:00.000Z'
+    }
+    // The harness does a canboatjs round-trip via pgnToActisenseSerialFormat,
+    // which would normalize away the broken value, so we bypass it.
+    var saved = process.env.NO_CANBOATJS
+    process.env.NO_CANBOATJS = 'true'
+    try {
+      var delta = mapper.toDelta(msg, {})
+      // No throw, and the mapper should emit zero values for an unknown
+      // alertType (the empty update wrapper itself is still constructed).
+      delta.updates[0].values.length.should.equal(0)
+    } finally {
+      if (saved === undefined) delete process.env.NO_CANBOATJS
+      else process.env.NO_CANBOATJS = saved
+    }
+  })
 })

--- a/test/126983_alert.js
+++ b/test/126983_alert.js
@@ -103,11 +103,19 @@ describe('126983 Alert', function () {
     delta.updates.length.should.equal(1)
   })
 
-  it('skips alerts with non-standard (integer) alertType without throwing', function () {
-    // Some devices emit alertType values outside the canboat ALERT_TYPE
-    // enum (1,2,5,8). canboatjs returns the raw integer in that case;
-    // previously the mapper crashed in node() and value() trying to call
-    // .replace on a number. The filter should drop these frames cleanly.
+  it("maps non-standard alertType to 'alert' state without throwing", function () {
+    var alertId = 9999
+    var nonStandardState = {
+      '128': {
+        alerts: {
+          [alertId]: {
+            languageId: 'English (US)',
+            locationTextDescription: '',
+            textDescription: 'TEST: non-standard alertType'
+          }
+        }
+      }
+    }
     var msg = {
       canId: 166725504,
       prio: 2,
@@ -117,7 +125,8 @@ describe('126983 Alert', function () {
       fields: {
         alertType: 4,
         alertCategory: 6,
-        alertSystem: 4
+        alertSystem: 4,
+        alertId: alertId
       },
       description: 'Alert',
       id: 'alert',
@@ -128,10 +137,17 @@ describe('126983 Alert', function () {
     var saved = process.env.NO_CANBOATJS
     process.env.NO_CANBOATJS = 'true'
     try {
-      var delta = mapper.toDelta(msg, {})
-      // No throw, and the mapper should emit zero values for an unknown
-      // alertType (the empty update wrapper itself is still constructed).
-      delta.updates[0].values.length.should.equal(0)
+      var delta = mapper.toDelta(msg, nonStandardState)
+      delta.updates[0].values.length.should.equal(1)
+      var v = delta.updates[0].values[0]
+      v.value.state.should.equal('alert')
+      // Raw alertType from the device is preserved verbatim in the value
+      // object, consistent with how every other field is exposed.
+      v.value.alertType.should.equal(4)
+      // Non-string alertCategory degrades to an empty path segment rather
+      // than crashing on .toLowerCase().
+      v.path.should.contain('.caution..')
+      v.path.should.equal('notifications.nmea.caution..4.' + alertId)
     } finally {
       if (saved === undefined) delete process.env.NO_CANBOATJS
       else process.env.NO_CANBOATJS = saved


### PR DESCRIPTION
## Summary

PGN 126983 (Alert) frames on a real N2K bus sometimes carry an `alertType` value outside the four standard `ALERT_TYPE` enum values (1=Emergency Alarm, 2=Alarm, 5=Warning, 8=Caution). When that happens, canboatjs falls back to returning the raw integer for the field, and the mapper crashed in two places:

- **`node` builder**: `n2k.fields.alertType.replace(...)` on a number → `TypeError: n2k.fields.alertType.replace is not a function`.
- **`value` builder**: `alertTypes.filter(a => a.nmea === n2k.fields.alertType)` returns an empty array; `skstate[0].sk` then throws.

Map alertType values that aren't one of the four canboat ALERT_TYPE enum strings to the `Caution` mapping (SK state `'alert'`), so the notification still surfaces at the lowest severity rather than being dropped on the floor. The original raw `alertType` value the device sent is preserved verbatim in the emitted value object, consistent with how every other field is exposed.

The path becomes `notifications.nmea.caution.<category>.<system>.<id>` for unknown alertType, matching how a real Caution frame would land.

`alertCategory` gets the same defensive treatment: a device misbehaving on alertType typically misbehaves on alertCategory too (the regression test exhibits `alertCategory: 6` alongside `alertType: 4`), and the existing `(n2k.fields.alertCategory || '').toLowerCase()` would crash on a number. Guard it with a `typeof === 'string'` check matching the style in [pgns/129794.js](pgns/129794.js); unknown category degrades to an empty path segment.

## Context

Surfaced while testing a candump-over-TCP gateway against a real bus with 47+ N2K devices. One of the bus devices emits PGN 126983 with `alertType: 4`, repeatedly. Every frame produced a `RangeError`/`TypeError` stack in the signalk-server log and tripped downstream consumers like `signalk-questdb` whose ILP writer ends up with `NaN.getTime()`.

This is independent of the canboatjs / signalk-server PRs we have open (canboat/canboatjs#437, SignalK/signalk-server#2694, SignalK/signalk-server#2693) — the same crash would fire on **any** N2K source feeding the mapper.

The fix lives entirely in n2k-signalk's per-PGN handler. canboat itself defines `ALERT_TYPE` correctly per spec (only 4 of 16 bit patterns assigned); canboatjs's lookup correctly falls through to the raw integer for unmapped values (`return name ? name : value`). It's the receiver's job to cope — that's what this PR makes the handler do.

## Test plan

- `npm run build` clean.
- `npm test` — all 185 tests pass, including the regression test renamed to "maps non-standard alertType to 'alert' state without throwing" with new assertions for the `'alert'` SK state, raw `alertType` preservation, and the empty-category path segment.
- `npx prettier-standard --check pgns/126983.js test/126983_alert.js` — code style verified.
