### PR TITLE
fix(130306): normalize true wind angle over water

### DIFF
--- a/pgns/130306.js
+++ b/pgns/130306.js
@@ -39,10 +39,13 @@ module.exports = [
     }
   },
   {
-    source: 'windAngle',
     node: 'environment.wind.angleTrueWater',
     filter: function (n2k) {
       return n2k.fields.reference === 'True (boat referenced)'
+    },
+    value: function (n2k) {
+      var angle = Number(n2k.fields.windAngle)
+      return angle <= Math.PI ? angle : angle - Math.PI * 2
     }
   },
   {

--- a/test/130306_wind_data.js
+++ b/test/130306_wind_data.js
@@ -69,6 +69,34 @@ describe('130306 Wind Data', function () {
     tree.should.be.validSignalKVesselIgnoringIdentity
   })
 
+  it('True Boat sentence converts positive gt 180', function () {
+    var tree = require('./testMapper').toNested(
+      JSON.parse(
+        '{"timestamp":"2013-10-08-15:47:28.264Z","prio":"2","src":"1","dst":"255","pgn":"130306","description":"Wind Data","fields":{"SID":"68","Wind Speed":4.89,"Wind Angle":3.3,"Reference":"True (boat referenced)"}}'
+      )
+    )
+    tree.should.have.nested.property('environment.wind.speedTrue.value', 4.89)
+    tree.should.have.nested.property(
+      'environment.wind.angleTrueWater.value',
+      -2.9831853071795864
+    )
+    tree.should.be.validSignalKVesselIgnoringIdentity
+  })
+
+  it('True Boat sentence converts negative', function () {
+    var tree = require('./testMapper').toNested(
+      JSON.parse(
+        '{"timestamp":"2013-10-08-15:47:28.264Z","prio":"2","src":"1","dst":"255","pgn":"130306","description":"Wind Data","fields":{"SID":"68","Wind Speed":4.89,"Wind Angle":4.8726,"Reference":"True (boat referenced)"}}'
+      )
+    )
+    tree.should.have.nested.property('environment.wind.speedTrue.value', 4.89)
+    tree.should.have.nested.property(
+      'environment.wind.angleTrueWater.value',
+      -1.410585307179586
+    )
+    tree.should.be.validSignalKVesselIgnoringIdentity
+  })
+
   it('True Ground sentence converts', function () {
     var tree = require('./testMapper').toNested(
       JSON.parse(


### PR DESCRIPTION
PGN 130306 was already normalizing `environment.wind.angleApparent` from the NMEA 2000 `0..2π` range into SignalK's signed wind-angle range, but `environment.wind.angleTrueWater` still copied the raw `windAngle` value through for `True (boat referenced)` frames.

This fix applies the same conversion to true wind angle over water, so values over `π` are emitted as negative port-side angles. North-referenced wind directions are left unchanged.

Closes #275