### PR TITLE
Add NMEA 2000 PGN 129808 (DSC Call Information) mapping

### DIFF
--- a/pgns/129808.js
+++ b/pgns/129808.js
@@ -1,0 +1,71 @@
+/*
+ * PGN 129808 "DSC Call Information" — VHF Digital Selective Calling.
+ *
+ * canboatjs (useCamel) resolves the DSC_FORMAT / DSC_CATEGORY / DSC_NATURE
+ * lookups to their names. canboat models two field variants of this PGN: the
+ * distress variant (dscFormat/dscCategory/natureOfDistress) and the general
+ * variant (dscFormatSymbol/dscCategorySymbol) — read both.
+ *
+ * Mirrors the NMEA 0183 $--DSC hook: the reported position and a
+ * nature-of-distress notification are emitted under the calling station's
+ * MMSI context.
+ */
+
+const NATURES = {
+  Fire: 'fire',
+  Flooding: 'flooding',
+  Collision: 'collision',
+  Grounding: 'grounding',
+  Listing: 'listing',
+  Sinking: 'sinking',
+  'Disabled and adrift': 'adrift',
+  Undesignated: 'undesignated',
+  'Abandoning ship': 'abandon',
+  Piracy: 'piracy',
+  'Man overboard': 'mob',
+  'EPIRB emission': 'epirb'
+}
+
+function callerMmsi (n2k) {
+  const address = n2k.fields.dscMessageAddress
+  if (address === undefined || address === null || Number(address) === 0) {
+    return undefined
+  }
+  return address.toString()
+}
+
+function isDistress (n2k) {
+  return (
+    n2k.fields.dscCategory === 'Distress' ||
+    n2k.fields.dscCategorySymbol === 'Distress'
+  )
+}
+
+function distressNature (n2k) {
+  return NATURES[n2k.fields.natureOfDistress] || 'undesignated'
+}
+
+module.exports = [
+  {
+    node: 'navigation.position',
+    filter: n2k =>
+      typeof n2k.fields.latitudeOfVesselReported === 'number' &&
+      typeof n2k.fields.longitudeOfVesselReported === 'number',
+    value: n2k => ({
+      latitude: n2k.fields.latitudeOfVesselReported,
+      longitude: n2k.fields.longitudeOfVesselReported
+    })
+  },
+  {
+    node: n2k => 'notifications.' + distressNature(n2k),
+    filter: isDistress,
+    value: n2k => ({
+      message:
+        'DSC Distress Received! Nature of distress: ' + distressNature(n2k)
+    })
+  },
+  {
+    context: n2k => 'vessels.urn:mrn:imo:mmsi:' + callerMmsi(n2k),
+    filter: n2k => typeof callerMmsi(n2k) !== 'undefined'
+  }
+]

--- a/pgns/index.js
+++ b/pgns/index.js
@@ -37,6 +37,7 @@ module.exports = {
   129540: require('./129540.js'),
   129793: require('./129793.js'),
   129794: require('./129794.js'),
+  129808: require('./129808.js'),
   129809: require('./129809.js'),
   129810: require('./129810.js'),
   130306: require('./130306.js'),

--- a/test/129808_dsc_call_information.js
+++ b/test/129808_dsc_call_information.js
@@ -1,0 +1,71 @@
+var chai = require('chai')
+chai.Should()
+chai.use(require('chai-things'))
+
+var mapper = require('./testMapper')
+
+describe('129808 DSC Call Information', function () {
+  it('distress alert maps position and a nature notification', function () {
+    var msg = {
+      timestamp: '2026-06-17-12:00:00.000',
+      prio: '8',
+      src: '12',
+      dst: '255',
+      pgn: '129808',
+      description: 'DSC Call Information',
+      fields: {
+        'DSC Format': 'Distress',
+        'DSC Category': 'Distress',
+        'DSC Message Address': '366191910',
+        'Nature of Distress': 'Sinking',
+        'Latitude of Vessel Reported': 48.76,
+        'Longitude of Vessel Reported': -123.0,
+        'MMSI of Ship In Distress': '366191910'
+      }
+    }
+    var delta = mapper.testToDelta(msg)
+
+    delta.context.should.equal('vessels.urn:mrn:imo:mmsi:366191910')
+
+    var position = delta.updates[0].values.find(
+      pathValue => pathValue.path === 'navigation.position'
+    )
+    position.value.latitude.should.be.closeTo(48.76, 0.0001)
+    position.value.longitude.should.be.closeTo(-123.0, 0.0001)
+
+    var notification = delta.updates[0].values.find(
+      pathValue => pathValue.path === 'notifications.sinking'
+    )
+    notification.should.not.equal(undefined)
+  })
+
+  it('non-distress call maps position without a notification', function () {
+    var msg = {
+      timestamp: '2026-06-17-12:00:00.000',
+      prio: '8',
+      src: '12',
+      dst: '255',
+      pgn: '129808',
+      description: 'DSC Call Information',
+      fields: {
+        'DSC format symbol': 'All ships',
+        'DSC category symbol': 'Safety',
+        'DSC Message Address': '366191910',
+        'Latitude of Vessel Reported': 48.76,
+        'Longitude of Vessel Reported': -123.0
+      }
+    }
+    var delta = mapper.testToDelta(msg)
+
+    delta.context.should.equal('vessels.urn:mrn:imo:mmsi:366191910')
+
+    var position = delta.updates[0].values.find(
+      pathValue => pathValue.path === 'navigation.position'
+    )
+    position.value.latitude.should.be.closeTo(48.76, 0.0001)
+
+    delta.updates[0].values.forEach(function (pathValue) {
+      pathValue.path.startsWith('notifications.').should.equal(false)
+    })
+  })
+})


### PR DESCRIPTION
PGN 129808 carries VHF Digital Selective Calling traffic — distress, urgency, safety, and routine calls — but had no mapping, so DSC received over NMEA 2000 produced no deltas at all.

This maps the reported position and a nature-of-distress notification under the calling station's MMSI context, mirroring the existing NMEA 0183 `$--DSC` hook so both transports surface DSC the same way. Covers both canboat field variants (distress and general). Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)