### PR TITLE
Fix PGN 127489 fuel.pressure and coolantPressure double scaling

### DIFF
--- a/pgns/127489.js
+++ b/pgns/127489.js
@@ -56,8 +56,8 @@ module.exports = [
       return 'propulsion.' + skEngineId(n2k) + '.coolantPressure'
     },
     value: function (n2k) {
-      var kpa = Number(n2k.fields.coolantPressure)
-      return isNaN(kpa) ? null : kpa * 1000.0
+      var pa = Number(n2k.fields.coolantPressure)
+      return isNaN(pa) ? null : pa
     }
   },
   {
@@ -83,8 +83,8 @@ module.exports = [
       return 'propulsion.' + skEngineId(n2k) + '.fuel.pressure'
     },
     value: function (n2k) {
-      var kpa = Number(n2k.fields.fuelPressure)
-      return isNaN(kpa) ? null : kpa * 1000.0
+      var pa = Number(n2k.fields.fuelPressure)
+      return isNaN(pa) ? null : pa
     }
   }
 ]

--- a/test/127489_engine_params.js
+++ b/test/127489_engine_params.js
@@ -16,12 +16,12 @@ describe('127489 engine parameters Port', function () {
     tree.should.have.nested.property('propulsion.port.coolantPressure')
     tree.should.have.nested.property(
       'propulsion.port.coolantPressure.value',
-      38900000
+      38900
     )
     tree.should.have.nested.property('propulsion.port.fuel.pressure')
     tree.should.have.nested.property(
       'propulsion.port.fuel.pressure.value',
-      504000000
+      504000
     )
 
     tree.should.have.nested.property('propulsion.port.temperature')
@@ -121,12 +121,12 @@ describe('127489 engine parameters Starboard', function () {
     tree.should.have.nested.property('propulsion.starboard.coolantPressure')
     tree.should.have.nested.property(
       'propulsion.starboard.coolantPressure.value',
-      38900000
+      38900
     )
     tree.should.have.nested.property('propulsion.starboard.fuel.pressure')
     tree.should.have.nested.property(
       'propulsion.starboard.fuel.pressure.value',
-      504000000
+      504000
     )
 
     tree.should.have.nested.property('propulsion.starboard.temperature')
@@ -278,12 +278,12 @@ describe('127489 engine parameters 2', function () {
     tree.should.have.nested.property('propulsion.2.coolantPressure')
     tree.should.have.nested.property(
       'propulsion.2.coolantPressure.value',
-      38900000
+      38900
     )
     tree.should.have.nested.property('propulsion.2.fuel.pressure')
     tree.should.have.nested.property(
       'propulsion.2.fuel.pressure.value',
-      28000000
+      28000
     )
 
     tree.should.have.nested.property('propulsion.2.temperature')

--- a/test/127489_engine_params.js
+++ b/test/127489_engine_params.js
@@ -281,10 +281,7 @@ describe('127489 engine parameters 2', function () {
       38900
     )
     tree.should.have.nested.property('propulsion.2.fuel.pressure')
-    tree.should.have.nested.property(
-      'propulsion.2.fuel.pressure.value',
-      28000
-    )
+    tree.should.have.nested.property('propulsion.2.fuel.pressure.value', 28000)
 
     tree.should.have.nested.property('propulsion.2.temperature')
     tree.should.have.nested.property('propulsion.2.temperature.value', 29.85)


### PR DESCRIPTION
## What

Removes the `* 1000.0` multiplication from `fuelPressure` and `coolantPressure` in the PGN 127489 mapper, and updates the corresponding test expectations to match.

## Why

The mapper multiplied both fields by 1000, producing values 1000× too high in downstream SignalK/InfluxDB pipelines. The variable was even named `kpa`, suggesting the code was written when `canboatjs` returned these fields in kPa. Current `@canboat/ts-pgns` `canboat.json` declares both fields with `Unit: "Pa", Resolution: 1000` — `canboatjs` already returns the value in Pa. The extra `× 1000` yielded GPa (billions of Pa) in the output.

`oilPressure` in the same mapper does NOT have this bug — it returns the value unmultiplied — so this PR aligns fuel and coolant with the already-correct pattern.

## Empirical evidence (see #334)

Vessel with 2× Volvo D12 engines and CPAC controller, engine at idle (~525 RPM):

| Field | Before (buggy) | After (this PR) |
|---|---|---|
| `propulsion.port.fuel.pressure` | `4 000 000 000` Pa (4 GPa = 40 000 bar) | `~3 560 000` Pa (35.6 bar) |

## Changes

- `pgns/127489.js`: remove `* 1000.0` on fuelPressure and coolantPressure value functions; rename local var `kpa` → `pa` for clarity
- `test/127489_engine_params.js`: three test blocks (Port, Starboard, instance 2) — expected values divided by 1000 to reflect the corrected scale

## Tests

Full test suite passes (`npm test` → 201 passing). PGN 127489-specific block:

```
127489 engine parameters Port
  ✓ every field in the PGN from the NMEA2000 spec converts
  ✓ complete engine params sentence converts
127489 engine parameters Starboard
  ✓ every field in the PGN from the NMEA2000 spec converts
  ✓ complete engine params sentence converts
  ✓ engine notifications work
127489 engine parameters 2
  ✓ every field in the PGN from the NMEA2000 spec converts
  ✓ complete engine params sentence converts
```

## Note on downstream consumers

This is a semantic fix — the values were incorrect before. Anyone whose consumers (Grafana panels, custom plugins, etc.) had been compensating for the 1000× inflation will need to adjust. That said, values in GPa are physically implausible and were almost certainly being ignored or filtered.

Closes #334