### PR TITLE
feat: add PGN 130567 watermaker mapping

### DIFF
--- a/pgns/130567.js
+++ b/pgns/130567.js
@@ -1,0 +1,179 @@
+const util = require('util')
+const { timeToSeconds } = require('../utils.js')
+
+// PGN 130567 carries no instance field, so all values map to instance 0.
+const wmId = () => 0
+
+function yesNo (n2k, field) {
+  const v = n2k.fields[field]
+  return typeof v === 'undefined' ? null : v === 'Yes'
+}
+
+function flowToCubicMetersPerSecond (n2k, field) {
+  const lph = Number(n2k.fields[field])
+  return isNaN(lph) ? null : lph / 3600000
+}
+
+module.exports = [
+  {
+    source: 'watermakerOperatingState',
+    node: n2k => `watermaker.${wmId(n2k)}.state`
+  },
+  {
+    node: n2k => `watermaker.${wmId(n2k)}.production`,
+    value: n2k => yesNo(n2k, 'productionStartStop')
+  },
+  {
+    node: n2k => `watermaker.${wmId(n2k)}.rinsing`,
+    value: n2k => yesNo(n2k, 'rinseStartStop')
+  },
+  {
+    node: n2k => `watermaker.${wmId(n2k)}.lowPressurePump`,
+    value: n2k => yesNo(n2k, 'lowPressurePumpStatus')
+  },
+  {
+    node: n2k => `watermaker.${wmId(n2k)}.highPressurePump`,
+    value: n2k => yesNo(n2k, 'highPressurePumpStatus')
+  },
+  {
+    node: n2k => `watermaker.${wmId(n2k)}.emergencyStop`,
+    value: n2k => yesNo(n2k, 'emergencyStop')
+  },
+  {
+    node: n2k => `watermaker.${wmId(n2k)}.flushMode`,
+    value: n2k => yesNo(n2k, 'flushModeStatus')
+  },
+  {
+    // canboat reports ppm, Signal K uses ratio
+    node: n2k => `watermaker.${wmId(n2k)}.salinity`,
+    value: n2k => {
+      const ppm = Number(n2k.fields.salinity)
+      return isNaN(ppm) ? null : ppm / 1000000
+    }
+  },
+  {
+    source: 'productWaterTemperature',
+    node: n2k => `watermaker.${wmId(n2k)}.productWaterTemperature`
+  },
+  {
+    source: 'preFilterPressure',
+    node: n2k => `watermaker.${wmId(n2k)}.preFilterPressure`
+  },
+  {
+    source: 'postFilterPressure',
+    node: n2k => `watermaker.${wmId(n2k)}.postFilterPressure`
+  },
+  {
+    source: 'feedPressure',
+    node: n2k => `watermaker.${wmId(n2k)}.feedPressure`
+  },
+  {
+    source: 'systemHighPressure',
+    node: n2k => `watermaker.${wmId(n2k)}.systemHighPressure`
+  },
+  {
+    node: n2k => `watermaker.${wmId(n2k)}.productWaterFlow`,
+    value: n2k => flowToCubicMetersPerSecond(n2k, 'productWaterFlow')
+  },
+  {
+    node: n2k => `watermaker.${wmId(n2k)}.brineWaterFlow`,
+    value: n2k => flowToCubicMetersPerSecond(n2k, 'brineWaterFlow')
+  },
+  {
+    node: n2k => `watermaker.${wmId(n2k)}.runTime`,
+    value: n2k => {
+      const t = n2k.fields.runTime
+      if (typeof t === 'number') {
+        return t
+      }
+      return timeToSeconds(t)
+    }
+  }
+]
+
+const warningNotifications = [
+  {
+    field: 'productSolenoidValveStatus',
+    name: 'productSolenoidValve',
+    message: 'Watermaker Product Solenoid Valve'
+  },
+  {
+    field: 'salinityStatus',
+    name: 'salinity',
+    message: 'Watermaker Salinity'
+  },
+  {
+    field: 'sensorStatus',
+    name: 'sensor',
+    message: 'Watermaker Sensor'
+  },
+  {
+    field: 'oilChangeIndicatorStatus',
+    name: 'oilChange',
+    message: 'Watermaker Oil Change'
+  },
+  {
+    field: 'filterStatus',
+    name: 'filter',
+    message: 'Watermaker Filter'
+  },
+  {
+    field: 'systemStatus',
+    name: 'system',
+    message: 'Watermaker System'
+  }
+]
+
+warningNotifications.forEach(notif => {
+  module.exports.push({
+    node: function (n2k) {
+      return util.format(
+        'notifications.watermaker.%s.%s',
+        wmId(n2k),
+        notif.name
+      )
+    },
+    filter: function (n2k) {
+      return typeof n2k.fields[notif.field] !== 'undefined'
+    },
+    value: function (n2k) {
+      if (n2k.fields[notif.field] === 'Warning') {
+        return {
+          state: 'alert',
+          method: ['visual'],
+          message: notif.message + ' Warning'
+        }
+      } else {
+        return {
+          state: 'normal',
+          method: [],
+          message: notif.message + ' is Normal'
+        }
+      }
+    }
+  })
+})
+
+module.exports.push({
+  node: function (n2k) {
+    return util.format('notifications.watermaker.%s.emergencyStop', wmId(n2k))
+  },
+  filter: function (n2k) {
+    return typeof n2k.fields.emergencyStop !== 'undefined'
+  },
+  value: function (n2k) {
+    if (n2k.fields.emergencyStop === 'Yes') {
+      return {
+        state: 'emergency',
+        method: ['visual', 'sound'],
+        message: 'Watermaker Emergency Stop'
+      }
+    } else {
+      return {
+        state: 'normal',
+        method: [],
+        message: 'Watermaker Emergency Stop is Normal'
+      }
+    }
+  }
+})

--- a/pgns/index.js
+++ b/pgns/index.js
@@ -46,6 +46,7 @@ module.exports = {
   130313: require('./130313.js'),
   130314: require('./130314.js'),
   130316: require('./130316.js'),
+  130567: require('./130567.js'),
   130577: require('./130577.js'),
   130842: require('./130842.js'),
   127501: require('./127501.js'),

--- a/test/130567_watermaker.js
+++ b/test/130567_watermaker.js
@@ -1,0 +1,77 @@
+var chai = require('chai')
+chai.Should()
+chai.use(require('chai-things'))
+chai.use(require('@signalk/signalk-schema').chaiModule)
+
+describe('130567 watermaker input setting and status', function () {
+  it('complete sentence converts', function () {
+    var tree = require('./testMapper').toNested(
+      JSON.parse(
+        '{"timestamp":"2026-07-16T12:00:00.000Z","prio":6,"src":22,"dst":255,"pgn":130567,"description":"Watermaker Input Setting and Status","fields":{"watermakerOperatingState":"Running","productionStartStop":"Yes","rinseStartStop":"No","lowPressurePumpStatus":"Yes","highPressurePumpStatus":"Yes","emergencyStop":"No","productSolenoidValveStatus":"OK","flushModeStatus":"No","salinityStatus":"OK","sensorStatus":"OK","oilChangeIndicatorStatus":"OK","filterStatus":"Warning","systemStatus":"OK","salinity":320,"productWaterTemperature":300.15,"preFilterPressure":100000,"postFilterPressure":98000,"feedPressure":100000,"systemHighPressure":5500000,"productWaterFlow":360,"brineWaterFlow":1800,"runTime":123456}}'
+      )
+    )
+    tree.should.have.nested.property('watermaker.0.state.value', 'Running')
+    tree.should.have.nested.property('watermaker.0.production.value', true)
+    tree.should.have.nested.property('watermaker.0.rinsing.value', false)
+    tree.should.have.nested.property('watermaker.0.lowPressurePump.value', true)
+    tree.should.have.nested.property(
+      'watermaker.0.highPressurePump.value',
+      true
+    )
+    tree.should.have.nested.property('watermaker.0.emergencyStop.value', false)
+    tree.should.have.nested.property('watermaker.0.flushMode.value', false)
+    tree.should.have.nested.property('watermaker.0.salinity.value', 0.00032)
+    tree.watermaker['0'].productWaterTemperature.value.should.be.closeTo(
+      300.15,
+      0.001
+    )
+    tree.should.have.nested.property(
+      'watermaker.0.preFilterPressure.value',
+      100000
+    )
+    tree.should.have.nested.property(
+      'watermaker.0.postFilterPressure.value',
+      98000
+    )
+    tree.should.have.nested.property('watermaker.0.feedPressure.value', 100000)
+    tree.should.have.nested.property(
+      'watermaker.0.systemHighPressure.value',
+      5500000
+    )
+    tree.should.have.nested.property(
+      'watermaker.0.productWaterFlow.value',
+      0.0001
+    )
+    tree.should.have.nested.property(
+      'watermaker.0.brineWaterFlow.value',
+      0.0005
+    )
+    tree.should.have.nested.property('watermaker.0.runTime.value', 123456)
+    tree.should.have.nested.property(
+      'notifications.watermaker.0.filter.value.state',
+      'alert'
+    )
+    tree.should.have.nested.property(
+      'notifications.watermaker.0.system.value.state',
+      'normal'
+    )
+    tree.should.have.nested.property(
+      'notifications.watermaker.0.emergencyStop.value.state',
+      'normal'
+    )
+    // no schema validation: the spec has no watermaker branch (yet)
+  })
+
+  it('undefined fields produce no values', function () {
+    var delta = require('./testMapper').testToDelta(
+      JSON.parse(
+        '{"timestamp":"2026-07-16T12:00:00.000Z","prio":6,"src":22,"dst":255,"pgn":130567,"description":"Watermaker Input Setting and Status","fields":{"watermakerOperatingState":"Stopped"}}'
+      )
+    )
+    var paths = delta.updates[0].values.map(v => v.path)
+    paths.should.include('watermaker.0.state')
+    paths.should.not.include('watermaker.0.production')
+    paths.should.not.include('watermaker.0.salinity')
+    paths.should.not.include('notifications.watermaker.0.filter')
+  })
+})


### PR DESCRIPTION
Adds a mapping for PGN 130567 (Watermaker Input Setting and Status), which canboatjs already decodes but n2k-signalk previously dropped.

Values map to `watermaker.<instance>.*` — the path convention already used by signalk-spectra-plugin. The PGN carries no instance field, so instance is fixed at 0:

- `state` — operating state lookup, passed through
- `production`, `rinsing`, `lowPressurePump`, `highPressurePump`, `emergencyStop`, `flushMode` — booleans
- `salinity` — ppm converted to ratio
- `productWaterTemperature` (K), `preFilterPressure`, `postFilterPressure`, `feedPressure`, `systemHighPressure` (Pa)
- `productWaterFlow`, `brineWaterFlow` — L/h converted to m³/s
- `runTime` (s)

The six OK/Warning status fields map to `notifications.watermaker.0.<name>` (`normal`/`alert`), and Emergency Stop raises an `emergency` notification.

There is no watermaker branch in the Signal K spec yet, so the test skips schema validation like other non-spec paths in this repo.

Fixes #278

Tested: unit tests round-tripping through canboatjs (`npm test`, 203 passing) and live against a Blue Water Desalination Legend Series watermaker via a Maretron IPG100 — all values and the product-solenoid-valve warning notification appeared as expected.