### PR TITLE
fix(130306): sign the true wind angle (angleTrueWater)

### DIFF
--- a/pgns/130306.js
+++ b/pgns/130306.js
@@ -39,10 +39,13 @@ module.exports = [
     }
   },
   {
-    source: 'windAngle',
     node: 'environment.wind.angleTrueWater',
     filter: function (n2k) {
       return n2k.fields.reference === 'True (boat referenced)'
+    },
+    value: function (n2k) {
+      var angle = Number(n2k.fields.windAngle)
+      return angle <= Math.PI ? angle : angle - Math.PI * 2
     }
   },
   {

--- a/test/130306_wind_data.js
+++ b/test/130306_wind_data.js
@@ -69,6 +69,20 @@ describe('130306 Wind Data', function () {
     tree.should.be.validSignalKVesselIgnoringIdentity
   })
 
+  it('True Boat sentence converts gt 180', function () {
+    var tree = require('./testMapper').toNested(
+      JSON.parse(
+        '{"timestamp":"2013-10-08-15:47:28.264Z","prio":"2","src":"1","dst":"255","pgn":"130306","description":"Wind Data","fields":{"SID":"68","Wind Speed":4.89,"Wind Angle":3.3,"Reference":"True (boat referenced)"}}'
+      )
+    )
+    tree.should.have.nested.property('environment.wind.speedTrue.value', 4.89)
+    tree.should.have.nested.property(
+      'environment.wind.angleTrueWater.value',
+      -2.9831853071795864
+    )
+    tree.should.be.validSignalKVesselIgnoringIdentity
+  })
+
   it('True Ground sentence converts', function () {
     var tree = require('./testMapper').toNested(
       JSON.parse(


### PR DESCRIPTION
## Problem

`environment.wind.angleTrueWater` passes the raw 0..2π N2K wind angle straight through (`source: 'windAngle'`), whereas `angleApparent` wraps it to (-π, π]. The Signal K spec defines both the same way — *"negative to port"* — so a port-side true wind angle is reported as e.g. `350°` instead of `-10°`, which misrenders on consumers that treat the value as signed.

## Change

Give `angleTrueWater` the same signed-wrap `value` function `angleApparent` already uses. Adds a `True (boat referenced)` >180° test proving the sign; the existing <180° case is unchanged.

`npm test` and `npm run ci-format` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwAeQKbZAExuKHT5Q4wgSk
