### PR TITLE
Add PGN 129801 (AIS Addressed Safety Related Message)

### DIFF
--- a/pgns/129801.js
+++ b/pgns/129801.js
@@ -1,0 +1,52 @@
+/*
+ * PGN 129801 "AIS Addressed Safety Related Message" — the free-text safety
+ * message an AIS station sends to one specific MMSI rather than broadcasting
+ * it: a coast station calling a single vessel, a ship-to-ship safety call.
+ *
+ * Companion to PGN 129802 (the broadcast variant, added in #333). Emits the
+ * text under the sending station's MMSI context, following the same
+ * `communication.ais.*` namespace, plus the addressee so a consumer can tell
+ * whether the message was directed at own vessel.
+ */
+
+function senderMmsi (n2k) {
+  const id = n2k.fields.sourceId
+  if (id === undefined || id === null || Number(id) === 0) {
+    return undefined
+  }
+  // Coast stations carry 00-prefixed MMSIs that arrive numerically (leading
+  // zeros dropped). Pad back to 9 digits so the context is a valid MMSI.
+  return id.toString().padStart(9, '0')
+}
+
+function addresseeMmsi (n2k) {
+  const id = n2k.fields.destinationId
+  if (id === undefined || id === null || Number(id) === 0) {
+    return undefined
+  }
+  return id.toString().padStart(9, '0')
+}
+
+function safetyText (n2k) {
+  const text = n2k.fields.safetyRelatedText
+  return typeof text === 'string' && text.trim().length > 0
+    ? text.trim()
+    : undefined
+}
+
+module.exports = [
+  {
+    node: 'communication.ais.safetyRelatedAddressed',
+    filter: n2k => typeof safetyText(n2k) !== 'undefined',
+    value: n2k => safetyText(n2k)
+  },
+  {
+    node: 'communication.ais.safetyRelatedAddressee',
+    filter: n2k => typeof addresseeMmsi(n2k) !== 'undefined',
+    value: n2k => addresseeMmsi(n2k)
+  },
+  {
+    context: n2k => 'vessels.urn:mrn:imo:mmsi:' + senderMmsi(n2k),
+    filter: n2k => typeof senderMmsi(n2k) !== 'undefined'
+  }
+]

--- a/pgns/index.js
+++ b/pgns/index.js
@@ -37,6 +37,7 @@ module.exports = {
   129540: require('./129540.js'),
   129793: require('./129793.js'),
   129794: require('./129794.js'),
+  129801: require('./129801.js'),
   129802: require('./129802.js'),
   129808: require('./129808.js'),
   129809: require('./129809.js'),

--- a/test/129801_ais_safety_addressed.js
+++ b/test/129801_ais_safety_addressed.js
@@ -1,0 +1,67 @@
+var chai = require('chai')
+chai.Should()
+chai.use(require('chai-things'))
+
+var mapper = require('./testMapper')
+
+describe('129801 AIS Addressed Safety Related Message', function () {
+  it('maps the text and addressee under the sending station MMSI context', function () {
+    var msg = {
+      timestamp: '2026-07-08-12:00:00.000',
+      prio: '5',
+      src: '43',
+      dst: '255',
+      pgn: '129801',
+      description: 'AIS Addressed Safety Related Message',
+      fields: {
+        'Message ID': '12',
+        'Source ID': '003160001',
+        'Sequence Number': '0',
+        'Destination ID': '224539240',
+        'Safety Related Text': 'REDUCE SPEED, DIVERS IN THE WATER'
+      }
+    }
+    var delta = mapper.testToDelta(msg)
+
+    delta.context.should.equal('vessels.urn:mrn:imo:mmsi:003160001')
+
+    var text = delta.updates[0].values.find(
+      pathValue => pathValue.path === 'communication.ais.safetyRelatedAddressed'
+    )
+    text.should.not.equal(undefined)
+    text.value.should.equal('REDUCE SPEED, DIVERS IN THE WATER')
+
+    var addressee = delta.updates[0].values.find(
+      pathValue => pathValue.path === 'communication.ais.safetyRelatedAddressee'
+    )
+    addressee.should.not.equal(undefined)
+    addressee.value.should.equal('224539240')
+  })
+
+  // canboatjs cannot round-trip an empty STRING_LAU, so exercise the empty /
+  // whitespace / trim handling directly against the mapping's filter+value.
+  it('trims the text and skips empty messages', function () {
+    var mapping = require('../pgns/129801.js')
+    var text = mapping.find(
+      m => m.node === 'communication.ais.safetyRelatedAddressed'
+    )
+    text
+      .value({ fields: { safetyRelatedText: '  PAN PAN  ' } })
+      .should.equal('PAN PAN')
+    text.filter({ fields: { safetyRelatedText: '' } }).should.equal(false)
+    text.filter({ fields: { safetyRelatedText: '   ' } }).should.equal(false)
+    text.filter({ fields: {} }).should.equal(false)
+  })
+
+  it('pads coast station MMSIs and skips a zero addressee', function () {
+    var mapping = require('../pgns/129801.js')
+    var addressee = mapping.find(
+      m => m.node === 'communication.ais.safetyRelatedAddressee'
+    )
+    addressee
+      .value({ fields: { destinationId: 3160001 } })
+      .should.equal('003160001')
+    addressee.filter({ fields: { destinationId: 0 } }).should.equal(false)
+    addressee.filter({ fields: {} }).should.equal(false)
+  })
+})


### PR DESCRIPTION
Follow-up to #333, which added the broadcast variant.

PGN 129801 is the same free-text safety message, but **addressed to one specific MMSI** instead of
broadcast: a coast station calling a single vessel, or a ship-to-ship safety call. Today it is not
mapped, so the text is dropped.

**What it emits**, following the namespace and conventions #333 established:

| path | value |
| --- | --- |
| `communication.ais.safetyRelatedAddressed` | the message text, trimmed |
| `communication.ais.safetyRelatedAddressee` | the destination MMSI, padded to 9 digits |

Context is the sending station's MMSI, and coast-station MMSIs are padded back to 9 digits the same
way #333 does — they arrive numerically with the leading zeros dropped.

The addressee path is the one addition beyond a straight copy of the broadcast mapping. It seemed
worth exposing: without it a consumer cannot tell whether a safety message was directed at own
vessel or at somebody else nearby. Happy to drop it, or to rename either path, if you would rather
keep the surface smaller or place these elsewhere.

**PGN 129797 (AIS Binary Broadcast Message) deliberately left out.** Its payload is an
application-specific bit field that canboat exposes undecoded (`binaryData` plus a bit count), so
publishing it raw would not give a consumer anything usable without ASM decoding. Happy to open a
separate issue if that is wanted.

**Testing**

New `test/129801_ais_safety_addressed.js`: a canboat round-trip asserting the text, the addressee
and the context, plus direct filter/value checks for trimming, for empty and whitespace-only text,
and for a zero addressee. Empty `STRING_LAU` cannot round-trip through canboatjs, so that part is
exercised against the mapping directly, as #333 does.

Full suite: 211 passing, 0 failing. `npm run ci-format` clean.