### PR TITLE
feat: pack canName directly from the address claim fields

### DIFF
--- a/n2kMapper.js
+++ b/n2kMapper.js
@@ -1,11 +1,70 @@
 const EventEmitter = require('events').EventEmitter
 var through = require('through')
 var debug = require('debug')('signalk:n2k-signalk')
-const toPgn = require('@canboat/canboatjs').toPgn
-const Uint64LE = require('int64-buffer').Uint64LE
-const PGN = require('@canboat/ts-pgns').PGN
+const {
+  PGN,
+  ManufacturerCodeValues,
+  IndustryCodeValues,
+  DeviceClassValues
+} = require('@canboat/ts-pgns')
 
 require('util').inherits(N2kMapper, EventEmitter)
+
+// Resolve one NAME field to its numeric code, masked to its width. A
+// lookup field arrives as the name the decoder resolves ('Furuno',
+// 'Marine Industry', 'Yes') or, when the value is missing from the
+// lookup table, as the raw number. A field the decoder suppressed as
+// unavailable (e.g. systemInstance 15) is absent from the object and
+// must re-encode as its all-ones sentinel — real devices on the bus
+// transmit claims with unavailable instance fields.
+function nameField (value, mask, table) {
+  if (value === undefined || value === null) return mask
+  if (typeof value === 'number') return value & mask
+  if (table && Object.prototype.hasOwnProperty.call(table, value)) {
+    return table[value] & mask
+  }
+  const n = Number(value)
+  return (Number.isNaN(n) ? mask : n) & mask
+}
+
+// canName is the device's 8-byte NAME — the wire payload of its ISO
+// Address Claim (PGN 60928, ISO 11783-5 layout) — rendered as hex.
+// Packing the bytes straight from the decoded fields replaces the
+// former round-trip through canboatjs' encoder, which was this
+// mapper's only encode-side dependency.
+function canNameFromClaim (fields) {
+  const manufacturer = nameField(
+    fields.manufacturerCode,
+    0x7ff,
+    ManufacturerCodeValues
+  )
+  const industry = nameField(fields.industryGroup, 0x07, IndustryCodeValues)
+  const deviceClass = nameField(fields.deviceClass, 0x7f, DeviceClassValues)
+  const arbitrary = nameField(fields.arbitraryAddressCapable, 0x01, {
+    Yes: 1,
+    No: 0
+  })
+  // Bytes 0-3: unique number (21 bits) then manufacturer (11 bits).
+  // 0x200000 = 2^21 — a plain shift would overflow into the sign bit
+  // of JavaScript's 32-bit shift semantics for manufacturer >= 1024.
+  const lo = nameField(fields.uniqueNumber, 0x1fffff) + manufacturer * 0x200000
+  const b4 =
+    nameField(fields.deviceInstanceLower, 0x07) |
+    (nameField(fields.deviceInstanceUpper, 0x1f) << 3)
+  // canboatjs' encoder matched the field by schema name as well as by
+  // camel id, so existing callers pass either 'spare' or 'Spare'.
+  const spare = fields.spare !== undefined ? fields.spare : fields.Spare
+  const b6 = nameField(spare, 0x01) | (deviceClass << 1)
+  const b7 =
+    nameField(fields.systemInstance, 0x0f) | (industry << 4) | (arbitrary << 7)
+  const name =
+    BigInt(lo) |
+    (BigInt(b4) << 32n) |
+    (BigInt(nameField(fields.deviceFunction, 0xff)) << 40n) |
+    (BigInt(b6) << 48n) |
+    (BigInt(b7) << 56n)
+  return name.toString(16)
+}
 
 var n2kMappings = {}
 Object.assign(n2kMappings, require('./pgns'))
@@ -116,7 +175,7 @@ N2kMapper.prototype.toDelta = function (n2k) {
     }
 
     if (n2k.pgn === 60928) {
-      const canName = new Uint64LE(toPgn(n2k)).toString(16)
+      const canName = canNameFromClaim(n2k.fields)
       if (
         this.state[n2k.src].canName &&
         this.state[n2k.src].canName != canName

--- a/package.json
+++ b/package.json
@@ -25,16 +25,15 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/SignalK/n2k-signalk",
   "dependencies": {
-    "@canboat/canboatjs": "^3.8.2",
     "@canboat/ts-pgns": "1.11.x",
     "camelcase": "^6.2.0",
     "debug": "^4.0.0",
-    "int64-buffer": "^0.99.1007",
     "JSONStream": "~1.3.0",
     "lodash": "^4.17.11",
     "through": ">=2.2.7 <3"
   },
   "devDependencies": {
+    "@canboat/canboatjs": "^3.8.2",
     "@signalk/server-api": "^1.39.0",
     "@signalk/signalk-schema": "1.3.1",
     "@tsconfig/node20": "^20.1.6",

--- a/test/meta.js
+++ b/test/meta.js
@@ -40,6 +40,38 @@ describe('Meta data works', function () {
     })
   })
 
+  it('Address Claim with unavailable instance fields', done => {
+    // Captured from a live Maretron device (wire bytes
+    // 01,51,36,11,01,6e,28,cf): the decoder suppresses fields at
+    // their unavailable sentinel — systemInstance 15 here — so they
+    // are absent from the object and must re-encode as all-ones in
+    // the canName, exactly as re-encoding the claim would.
+    const n2kMapper = new N2kMapper()
+    n2kMapper.on('n2kSourceMetadata', (n2k, meta) => {
+      meta.should.have.property('canName', 'cf286e0111365101')
+      done()
+    })
+    n2kMapper.toDelta({
+      prio: 6,
+      pgn: 60928,
+      dst: 255,
+      src: 24,
+      timestamp: '2026-08-04T16:08:51.503Z',
+      fields: {
+        uniqueNumber: 1462529,
+        manufacturerCode: 'Maretron',
+        deviceInstanceLower: 1,
+        deviceInstanceUpper: 0,
+        deviceFunction: 110,
+        spare: 0,
+        deviceClass: 'Safety systems',
+        industryGroup: 'Marine Industry',
+        arbitraryAddressCapable: 'Yes'
+      },
+      description: 'ISO Address Claim'
+    })
+  })
+
   it('Configuration Information', done => {
     const n2kMapper = new N2kMapper()
     n2kMapper.on('n2kSourceMetadata', (n2k, meta) => {


### PR DESCRIPTION
The mapper computed a device's canName by re-encoding the just-decoded ISO Address Claim through canboatjs' toPgn and reading the eight bytes back via Uint64LE — a full encoder round-trip to reconstruct bytes the decode came from, and the package's only runtime use of the encoder. Since canName is an identity key (it drives n2kSourceChanged, source state and device metadata), tying it to encoder conventions means an encoder behavior change could silently re-identify every device on the bus.

This packs the 8-byte NAME directly from the decoded fields instead: the ISO 11783-5 layout is fixed, lookup names resolve through the ts-pgns value tables the package already depends on, and fields the decoder suppresses at their unavailable sentinel (a live Maretron claims with systemInstance 15, which decodes to an absent field) re-encode as all-ones exactly like the encoder round-trip did. The 'Spare'-cased fixture key that canboatjs matched by schema name is also still accepted.

The second commit drops int64-buffer (only used here) and moves @canboat/canboatjs to devDependencies — no runtime require of it remains anywhere in the package, so the mapper becomes decoder-agnostic: it consumes decoded objects whether canboatjs or an analyzer-based pipeline produced them.

Tested: byte-identical canNames against the previous computation across every 60928 corpus entry plus an exhaustive sweep of all manufacturer / device-class / industry lookup names and boundary numerics (2335 cases), and across all 37 devices of a live NMEA 2000 bus decoded through both the canboatjs pipeline and signalk-server's analyzer pipeline. About 12x faster per claim (10.4µs to 0.8µs, though claims are rare so the win is architectural rather than hot-path). Full mocha suite passes (209, including a new regression test pinned to the live Maretron claim bytes); prettier-standard clean.