### PR TITLE
feat(j1939): map J1939 engine PGNs to Signal K paths

### DIFF
--- a/pgns/61444.js
+++ b/pgns/61444.js
@@ -1,0 +1,17 @@
+const { skJ1939EngineId } = require('../utils.js')
+
+// J1939 EEC1 (ECU #1) — engine speed. Arrives from canboat's J1939
+// schema flavor (the j1939-wasm connection type), fields in rpm.
+module.exports = [
+  {
+    node: function (n2k) {
+      return 'propulsion.' + skJ1939EngineId(n2k) + '.revolutions'
+    },
+    value: function (n2k) {
+      return Number(n2k.fields.engineRpm) / 60.0
+    },
+    filter: function (n2k) {
+      return typeof n2k.fields.engineRpm !== 'undefined'
+    }
+  }
+]

--- a/pgns/65226.js
+++ b/pgns/65226.js
@@ -1,0 +1,71 @@
+const { skJ1939EngineId } = require('../utils.js')
+
+// J1939 Active Trouble Codes (DM1) — the four fault lamps plus the
+// repeating SPN/FMI list. Mapped to a notification per engine: the
+// lamps carry the severity, the DTC list rides in the message. Lamp
+// fields are 2-bit BINARY — '00' is off, anything else (steady or
+// flashing) is on.
+
+const LAMPS = [
+  { field: 'redStopLampStatus', label: 'red stop lamp', state: 'alarm' },
+  {
+    field: 'malfunctionLampStatus',
+    label: 'malfunction lamp',
+    state: 'warn'
+  },
+  {
+    field: 'amberWarningLampStatus',
+    label: 'amber warning lamp',
+    state: 'warn'
+  },
+  { field: 'protectLampStatus', label: 'protect lamp', state: 'alert' }
+]
+
+const lampOn = (n2k, field) =>
+  typeof n2k.fields[field] !== 'undefined' && n2k.fields[field] !== '00'
+
+module.exports = [
+  {
+    node: function (n2k) {
+      return (
+        'notifications.propulsion.' + skJ1939EngineId(n2k) + '.troubleCodes'
+      )
+    },
+    value: function (n2k) {
+      const active = LAMPS.filter(l => lampOn(n2k, l.field))
+      // Most severe active lamp wins; LAMPS is ordered by severity.
+      const state = active.length > 0 ? active[0].state : 'normal'
+      // A no-fault DM1 carries one all-zero DTC, and short frames pad
+      // with FF — neither is a real trouble code.
+      const dtcs = (Array.isArray(n2k.fields.list)
+        ? n2k.fields.list
+        : []
+      ).filter(
+        d =>
+          typeof d.spn === 'string' &&
+          d.fmi !== undefined &&
+          !/^[0 ]+$/.test(d.spn) &&
+          !/^[fF ]+$/.test(d.spn)
+      )
+      let message = 'No active trouble codes'
+      if (active.length > 0 || dtcs.length > 0) {
+        const parts = active.map(l => l.label)
+        if (dtcs.length > 0) {
+          parts.push(
+            dtcs.length +
+              ' trouble code' +
+              (dtcs.length > 1 ? 's' : '') +
+              ': ' +
+              dtcs.map(d => 'SPN ' + d.spn + ' FMI ' + d.fmi).join(', ')
+          )
+        }
+        message = parts.join('; ')
+      }
+      return {
+        state,
+        method: state === 'normal' ? [] : ['visual', 'sound'],
+        message
+      }
+    }
+  }
+]

--- a/pgns/65262.js
+++ b/pgns/65262.js
@@ -1,0 +1,15 @@
+const { skJ1939EngineId } = require('../utils.js')
+
+// J1939 Engine Temp #1 — coolant temperature (Kelvin from the SI
+// decode).
+module.exports = [
+  {
+    node: function (n2k) {
+      return 'propulsion.' + skJ1939EngineId(n2k) + '.coolantTemperature'
+    },
+    source: 'engineCoolantTemp',
+    filter: function (n2k) {
+      return typeof n2k.fields.engineCoolantTemp !== 'undefined'
+    }
+  }
+]

--- a/pgns/65270.js
+++ b/pgns/65270.js
@@ -1,0 +1,15 @@
+const { skJ1939EngineId } = require('../utils.js')
+
+// J1939 Inlet/Exhaust Conditions — intake manifold temperature
+// (Kelvin from the SI decode).
+module.exports = [
+  {
+    node: function (n2k) {
+      return 'propulsion.' + skJ1939EngineId(n2k) + '.intakeManifoldTemperature'
+    },
+    source: 'intakeManifoldTemp',
+    filter: function (n2k) {
+      return typeof n2k.fields.intakeManifoldTemp !== 'undefined'
+    }
+  }
+]

--- a/pgns/index.js
+++ b/pgns/index.js
@@ -1,4 +1,9 @@
 module.exports = {
+  // J1939 (canboat's J1939 schema flavor; the j1939-wasm connection)
+  61444: require('./61444.js'),
+  65226: require('./65226.js'),
+  65262: require('./65262.js'),
+  65270: require('./65270.js'),
   126983: require('./126983.js'),
   126985: require('./126985.js'),
   126992: require('./126992.js'),

--- a/test/61444_j1939_engine_speed.js
+++ b/test/61444_j1939_engine_speed.js
@@ -1,0 +1,20 @@
+var chai = require('chai')
+chai.Should()
+chai.use(require('chai-things'))
+chai.use(require('@signalk/signalk-schema').chaiModule)
+
+describe('61444 J1939 EEC1 engine speed', function () {
+  it('engine rpm converts, engine id from source address', function () {
+    var tree = require('./testMapper').n2kToNested(
+      JSON.parse(
+        '{"timestamp":"2026-08-06T00:00:00.000Z","prio":3,"src":0,"dst":255,"pgn":61444,"description":"ECU #1","fields":{"engineRpm":113.2}}'
+      )
+    )
+    tree.should.have.nested.property('propulsion.0.revolutions')
+    tree.should.have.nested.property(
+      'propulsion.0.revolutions.value',
+      113.2 / 60.0
+    )
+    tree.should.be.validSignalKVesselIgnoringIdentity
+  })
+})

--- a/test/65226_j1939_trouble_codes.js
+++ b/test/65226_j1939_trouble_codes.js
@@ -1,0 +1,34 @@
+var chai = require('chai')
+chai.Should()
+chai.use(require('chai-things'))
+chai.use(require('@signalk/signalk-schema').chaiModule)
+
+describe('65226 J1939 active trouble codes', function () {
+  it('all lamps off maps to a normal notification', function () {
+    var tree = require('./testMapper').n2kToNested(
+      JSON.parse(
+        '{"timestamp":"2026-08-06T00:00:00.000Z","prio":6,"src":0,"dst":255,"pgn":65226,"description":"Active Trouble Codes","fields":{"malfunctionLampStatus":"00","redStopLampStatus":"00","amberWarningLampStatus":"00","protectLampStatus":"00"}}'
+      )
+    )
+    tree.should.have.nested.property(
+      'notifications.propulsion.0.troubleCodes.value.state',
+      'normal'
+    )
+  })
+
+  it('red stop lamp maps to an alarm with the DTC list in the message', function () {
+    var tree = require('./testMapper').n2kToNested(
+      JSON.parse(
+        '{"timestamp":"2026-08-06T00:00:00.000Z","prio":6,"src":0,"dst":255,"pgn":65226,"description":"Active Trouble Codes","fields":{"malfunctionLampStatus":"00","redStopLampStatus":"40","amberWarningLampStatus":"00","protectLampStatus":"00","list":[{"spn":"00 03 60","fmi":"03","occurrenceCount":1}]}}'
+      )
+    )
+    tree.should.have.nested.property(
+      'notifications.propulsion.0.troubleCodes.value.state',
+      'alarm'
+    )
+    var value = tree.notifications.propulsion['0'].troubleCodes.value
+    value.message.should.contain('red stop lamp')
+    value.message.should.contain('SPN 00 03 60 FMI 03')
+    value.method.should.deep.equal(['visual', 'sound'])
+  })
+})

--- a/test/65262_j1939_engine_temp.js
+++ b/test/65262_j1939_engine_temp.js
@@ -1,0 +1,20 @@
+var chai = require('chai')
+chai.Should()
+chai.use(require('chai-things'))
+chai.use(require('@signalk/signalk-schema').chaiModule)
+
+describe('65262 J1939 engine temp', function () {
+  it('coolant temperature converts (Kelvin)', function () {
+    var tree = require('./testMapper').n2kToNested(
+      JSON.parse(
+        '{"timestamp":"2026-08-06T00:00:00.000Z","prio":6,"src":0,"dst":255,"pgn":65262,"description":"Engine Temp #1","fields":{"engineCoolantTemp":323.15}}'
+      )
+    )
+    tree.should.have.nested.property('propulsion.0.coolantTemperature')
+    tree.should.have.nested.property(
+      'propulsion.0.coolantTemperature.value',
+      323.15
+    )
+    tree.should.be.validSignalKVesselIgnoringIdentity
+  })
+})

--- a/utils.js
+++ b/utils.js
@@ -16,6 +16,13 @@ function skEngineId (n2k) {
   }
 }
 
+function skJ1939EngineId (n2k) {
+  // J1939 PGNs carry no engine-instance field; on a J1939 bus the
+  // source address is the engine identity (engine #1 claims 0x00,
+  // engine #2 0x01, ...).
+  return n2k.src
+}
+
 function skEngineTitle (n2k) {
   var engine = skEngineId(n2k)
   if (typeof engine === 'number') {
@@ -56,6 +63,7 @@ function timeToSeconds (time) {
 module.exports = {
   chooseField,
   skEngineId,
+  skJ1939EngineId,
   skEngineTitle,
   acPhase,
   timeToSeconds


### PR DESCRIPTION
Groundwork for a J1939 connection type in Signal K: canboat is growing a J1939 schema flavor (canboat/canboat#820) that decodes plain J1939 buses (engines, gensets) over socketcan, and signalk-server gets a listen-only `j1939-wasm` connection feeding those records through this mapper.

Mappings for what canboat's J1939 database defines today: EEC1 61444 → `propulsion.<id>.revolutions`, Engine Temp 65262 → `.coolantTemperature`, Inlet/Exhaust 65270 → `.intakeManifoldTemperature`, and Active Trouble Codes 65226 → a per-engine notification — lamp severity maps to alarm (red stop) / warn (malfunction, amber) / alert (protect), the SPN/FMI list rides in the message, and no-fault zero DTCs plus FF padding are filtered out.

J1939 PGNs carry no engine-instance field, so the engine identity is the source address (engine #1 claims 0x00, #2 0x01). The new tests use the direct mapping path rather than the canboatjs double-convert, which cannot round-trip PGNs canboatjs has no definitions for.

Tested: `npm test` green (212 passing — 4 new tests); end-to-end against a real Yamaha outboard candump capture through the wasm J1939 decoder into deltas (revolutions, both temperatures, and the trouble-code notification all produced; 535 delta values over the log).