### PR TITLE
Stop emitting NaN for AtoN reference point offsets (PGN 129041)

### DIFF
--- a/aisFromStarboard.js
+++ b/aisFromStarboard.js
@@ -1,9 +1,8 @@
+// NMEA 2000 reports the AIS reference point as an unsigned distance from
+// the starboard side. Signal K's sensors.*.fromCenter is measured from the
+// centerline, +ve to starboard, so subtract the half beam.
 module.exports = function (n2k) {
   var fromStarboard = n2k.fields.positionReferenceFromStarboard
   var width = n2k.fields.beam
-  if (fromStarboard > width / 2) {
-    return (fromStarboard - width / 2) * -1
-  } else {
-    return width / 2 - fromStarboard
-  }
+  return width / 2 - fromStarboard
 }

--- a/atonFromStarboardEdge.js
+++ b/atonFromStarboardEdge.js
@@ -1,0 +1,9 @@
+// PGN 129041 (AtoN) names its dimension fields differently from the vessel
+// AIS PGNs: positionReferenceFromStarboardEdge / beamDiameter rather than
+// positionReferenceFromStarboard / beam. Signal K's sensors.*.fromCenter is
+// measured from the centerline, +ve to starboard, so subtract the half beam.
+module.exports = function (n2k) {
+  var fromStarboardEdge = n2k.fields.positionReferenceFromStarboardEdge
+  var width = n2k.fields.beamDiameter
+  return width / 2 - fromStarboardEdge
+}

--- a/pgns/129041.ts
+++ b/pgns/129041.ts
@@ -1,7 +1,7 @@
 import { PGN_129041, AtonType } from '@canboat/ts-pgns'
 
 import { getMmsiContext } from '../mmsi-context'
-import getFromStarboard from '../aisFromStarboard'
+import getFromStarboardEdge from '../atonFromStarboardEdge'
 const schema = require('@signalk/signalk-schema')
 
 module.exports = [
@@ -55,16 +55,16 @@ module.exports = [
     node: 'design.beam',
     source: 'beamDiameter'
   },
-  {
-    node: 'sensors.ais.fromBow',
-    source: 'positionReferenceFromBow'
-  },
+  // No fromBow equivalent: an AtoN has no bow, and PGN 129041 references its
+  // position from the true-north-facing edge rather than from a bow.
   {
     node: 'sensors.ais.fromCenter',
-    value: getFromStarboard,
+    value: getFromStarboardEdge,
     filter: function (n2k: PGN_129041) {
       return (
-        n2k.fields.positionReferenceFromStarboardEdge && n2k.fields.beamDiameter
+        typeof n2k.fields.positionReferenceFromStarboardEdge === 'number' &&
+        typeof n2k.fields.beamDiameter === 'number' &&
+        n2k.fields.beamDiameter > 0
       )
     }
   },

--- a/pgns/129793.js
+++ b/pgns/129793.js
@@ -1,5 +1,4 @@
 const padUserID = require('../mmsi-context').padUserID
-const getFromStarboard = require('../aisFromStarboard')
 const getShipType = require('../aisShipTypeMapping')
 
 module.exports = [

--- a/test/129041_aton_report.js
+++ b/test/129041_aton_report.js
@@ -24,4 +24,18 @@ describe('129041 AIS Aids to Navigation (AtoN) Report', function () {
     tree.navigation.position.value.longitude.should.equal(-76.3847132)
     // tree.should.be.validSignalKAtoNIgnoringIdentity;
   })
+
+  it('converts the reference point offsets', function () {
+    // Beam diameter 6, reference point 2m in from the starboard edge, so
+    // the reference point is 1m to starboard of the centerline: 6/2 - 2.
+    var msg = JSON.parse(
+      '{"timestamp":"2017-03-14T19:02:40.451Z","prio":4,"src":43,"dst":255,"pgn":129041,"description":"AIS Aids to Navigation (AtoN) Report","fields":{"Message ID":21,"Repeat Indicator":"Initial","User ID":993672315,"Longitude":-76.3847132,"Latitude":38.9938400,"Position Accuracy":"High","AIS RAIM Flag":"not in use","Time Stamp":"Manual input mode","Length/Diameter":12.0,"Beam/Diameter":6.0,"Position Reference from Starboard Edge":2.0,"Position Reference from True North Facing Edge":3.0,"AtoN Type":"Fixed beacon: port hand","Off Position Indicator":"No","Virtual AtoN Flag":"No","Assigned Mode Flag":"Autonomous and continuous","AIS Spare":"0","Position Fixing Device Type":"Surveyed","AtoN Status":"0","AIS Transceiver information":"Channel B VDL reception","AtoN Name":"SW                  @"}}'
+    )
+    var tree = mapper.toNested(msg)
+    // Guard explicitly against NaN: chai's equal would also fail on NaN,
+    // but a bare value assertion reads as if only the number were wrong.
+    Number.isFinite(tree.sensors.ais.fromCenter.value).should.equal(true)
+    tree.sensors.ais.fromCenter.value.should.equal(1)
+    tree.should.have.nested.property('design.beam.value', 6.0)
+  })
 })


### PR DESCRIPTION
PGN 129041 (AtoN) publishes `sensors.ais.fromCenter` as **`NaN`**, and `sensors.ais.fromBow` never populates at all.

## Cause

PGN 129041 names its dimension fields differently from the vessel AIS PGNs: `positionReferenceFromStarboardEdge` and `beamDiameter`, rather than `positionReferenceFromStarboard` and `beam`.

The mapping filtered on the correct AtoN names but delegated the value to `aisFromStarboard`, which reads the *vessel* names. So on real AtoN data the filter passed, the helper computed on two `undefined`s, and returned `NaN`:

```js
undefined > undefined/2   // false
undefined/2 - undefined   // NaN
```

The `NaN` reaches the tree because the `isNaN` guard in `n2kMapper` only covers the `source:` branch, while this mapping uses `value:`. It is not valid JSON, so it serialises to `null` — consumers see a null-valued path rather than an absent one.

`fromBow` read `positionReferenceFromBow`, which 129041 does not define either; that one failed quietly to `undefined`.

## Fix

Adds an AtoN-specific helper reading the correct fields. The two PGN families differ in semantics as well as naming — a buoy's beam *diameter* is not a vessel's beam — so sharing one helper was the root mistake.

**Drops `sensors.ais.fromBow` for AtoN.** An AtoN has no bow; PGN 129041 references its position from the true-north-facing edge, and publishing that under a bow-named path would be misleading. Happy to map it to something else if you'd rather — flagging it as a judgement call rather than a rename.

The filter now type-checks instead of testing truthiness, so a reference point exactly on the starboard edge (`0`) is no longer skipped.

Also simplifies `aisFromStarboard` (both branches computed the same expression, `beam/2 - fromStarboard`; verified identical across all sampled beams and offsets) and removes a dead import in `129793`.

## Note on the sign convention

This does **not** change any sign. `aisFromStarboard` emits +ve to starboard, which contradicts the current spec wording but matches what the rest of the ecosystem does in practice — see RFC SignalK/specification#685 and SignalK/specification#680, which propose making the spec match. Deliberately kept separate so this bug fix can land either way.

## Tested

Full suite passes (209). The existing 129041 fixture is a *virtual* AtoN carrying no dimension fields, which is why this went unnoticed — adds one with real dimensions asserting a finite value explicitly via `Number.isFinite`, since a bare equality assertion against `NaN` reads as if only the number were wrong. Confirmed the new test fails if the old helper wiring is restored.